### PR TITLE
support for dao.initSql + working dao.minIdle with HikariCP

### DIFF
--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -41,11 +41,6 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.jolbox</groupId>
-            <artifactId>bonecp</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>com.mchange</groupId>
             <artifactId>c3p0</artifactId>
             <optional>true</optional>

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
@@ -44,7 +44,7 @@ public interface DaoConfig {
 
     @Description("The minimum allowed number of idle connections to the database")
     @Config("org.killbill.dao.minIdle")
-    @Default("1")
+    @Default("0")
     int getMinIdle();
 
     @Description("The maximum allowed number of active connections to the database")
@@ -122,5 +122,5 @@ public interface DaoConfig {
     @Config("org.killbill.dao.poolingType")
     @Default("HIKARICP")
     DataSourceConnectionPoolingType getConnectionPoolingType();
-    
+
 }

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
@@ -73,6 +73,11 @@ public interface DaoConfig {
     @Default("5m")
     TimeSpan getIdleConnectionTestPeriod();
 
+    @Description("Sets a SQL statement executed after every new connection creation before adding it to the pool")
+    @Config("org.killbill.dao.connectionInitSql")
+    @DefaultNull
+    String getConnectionInitSql();
+
     @Description("Number of prepared statements that the driver will cache per connection")
     @Config("org.killbill.dao.prepStmtCacheSize")
     @Default("500")
@@ -117,4 +122,5 @@ public interface DaoConfig {
     @Config("org.killbill.dao.poolingType")
     @Default("HIKARICP")
     DataSourceConnectionPoolingType getConnectionPoolingType();
+    
 }

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceConnectionPoolingType.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceConnectionPoolingType.java
@@ -20,6 +20,5 @@ package org.killbill.commons.jdbi.guice;
 
 public enum DataSourceConnectionPoolingType {
     C3P0,
-    BONECP,
     HIKARICP
 }

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceProvider.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceProvider.java
@@ -28,8 +28,6 @@ import javax.sql.DataSource;
 import org.skife.config.TimeSpan;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.jolbox.bonecp.BoneCPConfig;
-import com.jolbox.bonecp.BoneCPDataSource;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -78,9 +76,6 @@ public class DataSourceProvider implements Provider<DataSource> {
         if (DataSourceConnectionPoolingType.C3P0.equals(config.getConnectionPoolingType())) {
             loadDriver();
             ds = getC3P0DataSource();
-        } else if (DataSourceConnectionPoolingType.BONECP.equals(config.getConnectionPoolingType())) {
-            loadDriver();
-            ds = getBoneCPDatSource();
         } else if (DataSourceConnectionPoolingType.HIKARICP.equals(config.getConnectionPoolingType())) {
             if (dataSourceClassName != null) {
                 loadDriver();
@@ -141,25 +136,6 @@ public class DataSourceProvider implements Provider<DataSource> {
         }
 
         return new HikariDataSource(hikariConfig);
-    }
-
-    private DataSource getBoneCPDatSource() {
-        final BoneCPConfig dbConfig = new BoneCPConfig();
-        dbConfig.setJdbcUrl(config.getJdbcUrl());
-        dbConfig.setUsername(config.getUsername());
-        dbConfig.setPassword(config.getPassword());
-        dbConfig.setMinConnectionsPerPartition(config.getMinIdle());
-        dbConfig.setMaxConnectionsPerPartition(config.getMaxActive());
-        dbConfig.setConnectionTimeout(config.getConnectionTimeout().getPeriod(), config.getConnectionTimeout().getUnit());
-        dbConfig.setIdleMaxAge(config.getIdleMaxAge().getPeriod(), config.getIdleMaxAge().getUnit());
-        dbConfig.setMaxConnectionAge(config.getMaxConnectionAge().getPeriod(), config.getMaxConnectionAge().getUnit());
-        dbConfig.setIdleConnectionTestPeriod(config.getIdleConnectionTestPeriod().getPeriod(), config.getIdleConnectionTestPeriod().getUnit());
-        dbConfig.setPartitionCount(1);
-        dbConfig.setDisableJMX(false);
-        dbConfig.setStatementsCacheSize(config.getPreparedStatementsCacheSize());
-        dbConfig.setPoolName(poolName);
-
-        return new BoneCPDataSource(dbConfig);
     }
 
     private DataSource getC3P0DataSource() {

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceProvider.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceProvider.java
@@ -89,8 +89,8 @@ public class DataSourceProvider implements Provider<DataSource> {
 
             hikariConfig.setUsername(config.getUsername());
             hikariConfig.setPassword(config.getPassword());
-            hikariConfig.setMinimumIdle(config.getMinIdle());
             hikariConfig.setMaximumPoolSize(config.getMaxActive());
+            hikariConfig.setMinimumIdle(config.getMinIdle());
             hikariConfig.setConnectionTimeout(toMilliSeconds(config.getConnectionTimeout()));
             hikariConfig.setIdleTimeout(toMilliSeconds(config.getIdleMaxAge()));
             hikariConfig.setMaxLifetime(toMilliSeconds(config.getMaxConnectionAge()));

--- a/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
+++ b/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
@@ -137,37 +137,30 @@ public class TestDataSourceProvider {
             }
         }
 
-        @Override
         public Connection connect(String url, Properties info) throws SQLException {
             return null;
         }
 
-        @Override
         public boolean acceptsURL(String url) throws SQLException {
             return url.contains("oracle");
         }
 
-        @Override
         public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
             return new DriverPropertyInfo[0];
         }
 
-        @Override
         public int getMajorVersion() {
             return 0;
         }
 
-        @Override
         public int getMinorVersion() {
             return 0;
         }
 
-        @Override
         public boolean jdbcCompliant() {
             return false;
         }
 
-        @Override
         public Logger getParentLogger() throws SQLFeatureNotSupportedException {
             return null;
         }

--- a/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
+++ b/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
@@ -37,15 +37,16 @@ import com.zaxxer.hikari.HikariDataSource;
 
 public class TestDataSourceProvider {
 
-    private static final String TEST_POOL = "test-pool";
+    private static final String TEST_POOL_PREFIX = "test-pool";
 
     @Test(groups = "fast")
     public void testDataSourceProviderHikariCP() throws Exception {
-        for (final DataSourceProvider.DatabaseType databaseType : DataSourceProvider.DatabaseType.values()) {
-            for (final boolean shouldUseMariaDB : new boolean[]{false, true}) {
+        for ( final DataSourceProvider.DatabaseType databaseType : DataSourceProvider.DatabaseType.values() ) {
+            for ( final boolean shouldUseMariaDB : new boolean[] { false, true } ) {
                 final DaoConfig daoConfig = buildDaoConfig(DataSourceConnectionPoolingType.HIKARICP, databaseType);
 
-                final DataSourceProvider dataSourceProvider = new DataSourceProvider(daoConfig, TEST_POOL, shouldUseMariaDB);
+                final String poolName = TEST_POOL_PREFIX + "-" + databaseType + "_" + shouldUseMariaDB;
+                final DataSourceProvider dataSourceProvider = new DataSourceProvider(daoConfig, poolName, shouldUseMariaDB);
 
                 final DataSource dataSource = dataSourceProvider.get();
                 assertTrue(dataSource instanceof HikariDataSource);
@@ -58,14 +59,14 @@ public class TestDataSourceProvider {
         final DataSourceConnectionPoolingType poolingType = DataSourceConnectionPoolingType.HIKARICP;
 
         DataSourceProvider.DatabaseType databaseType = DataSourceProvider.DatabaseType.H2;
-        boolean shouldUseMariaDB = true;
 
         final Properties properties = defaultDaoConfigProperties(poolingType, databaseType);
         properties.put("org.killbill.dao.minIdle", "20");
         properties.put("org.killbill.dao.maxActive", "50");
         final DaoConfig daoConfig = buildDaoConfig(properties);
 
-        final DataSource dataSource = new DataSourceProvider(daoConfig, TEST_POOL, shouldUseMariaDB).get();
+        final String poolName = TEST_POOL_PREFIX + "-1";
+        final DataSource dataSource = new DataSourceProvider(daoConfig, poolName).get();
         assertTrue(dataSource instanceof HikariDataSource);
 
         HikariDataSource hikariDataSource = (HikariDataSource) dataSource;
@@ -78,13 +79,14 @@ public class TestDataSourceProvider {
         final DataSourceConnectionPoolingType poolingType = DataSourceConnectionPoolingType.HIKARICP;
 
         DataSourceProvider.DatabaseType databaseType = DataSourceProvider.DatabaseType.H2;
-        boolean shouldUseMariaDB = true;
+        final boolean shouldUseMariaDB = true;
 
         final Properties properties = defaultDaoConfigProperties(poolingType, databaseType);
         properties.put("org.killbill.dao.connectionInitSql", "SELECT 42");
         final DaoConfig daoConfig = buildDaoConfig(properties);
 
-        final DataSource dataSource = new DataSourceProvider(daoConfig, TEST_POOL, shouldUseMariaDB).get();
+        final String poolName = TEST_POOL_PREFIX + "-2";
+        final DataSource dataSource = new DataSourceProvider(daoConfig, poolName, shouldUseMariaDB).get();
         assertTrue(dataSource instanceof HikariDataSource);
 
         HikariDataSource hikariDataSource = (HikariDataSource) dataSource;
@@ -93,11 +95,12 @@ public class TestDataSourceProvider {
 
     @Test(groups = "fast")
     public void testDataSourceProviderC3P0() throws Exception {
-        for (final DataSourceProvider.DatabaseType databaseType : DataSourceProvider.DatabaseType.values()) {
-            for (final boolean shouldUseMariaDB : new boolean[]{false, true}) {
+        for ( final DataSourceProvider.DatabaseType databaseType : DataSourceProvider.DatabaseType.values() ) {
+            for ( final boolean shouldUseMariaDB : new boolean[] { false, true } ) {
                 final DaoConfig daoConfig = buildDaoConfig(DataSourceConnectionPoolingType.C3P0, databaseType);
 
-                final DataSourceProvider dataSourceProvider = new DataSourceProvider(daoConfig, TEST_POOL, shouldUseMariaDB);
+                final String poolName = TEST_POOL_PREFIX + "-" + databaseType + "_C3P0";
+                final DataSourceProvider dataSourceProvider = new DataSourceProvider(daoConfig, poolName, shouldUseMariaDB);
 
                 final DataSource dataSource = dataSourceProvider.get();
                 assertTrue(dataSource instanceof ComboPooledDataSource);

--- a/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
+++ b/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
@@ -32,7 +32,6 @@ import org.skife.config.ConfigurationObjectFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.jolbox.bonecp.BoneCPDataSource;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.zaxxer.hikari.HikariDataSource;
 
@@ -50,20 +49,6 @@ public class TestDataSourceProvider {
 
                 final DataSource dataSource = dataSourceProvider.get();
                 Assert.assertTrue(dataSource instanceof HikariDataSource);
-            }
-        }
-    }
-
-    @Test(groups = "fast")
-    public void testDataSourceProviderBoneCP() throws Exception {
-        for (final DataSourceProvider.DatabaseType databaseType : DataSourceProvider.DatabaseType.values()) {
-            for (final boolean shouldUseMariaDB : new boolean[]{false, true}) {
-                final DaoConfig daoConfig = buildDaoConfig(DataSourceConnectionPoolingType.BONECP, databaseType);
-
-                final DataSourceProvider dataSourceProvider = new DataSourceProvider(daoConfig, TEST_POOL, shouldUseMariaDB);
-
-                final DataSource dataSource = dataSourceProvider.get();
-                Assert.assertTrue(dataSource instanceof BoneCPDataSource);
             }
         }
     }

--- a/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
+++ b/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
@@ -74,6 +74,24 @@ public class TestDataSourceProvider {
     }
 
     @Test(groups = "fast")
+    public void testDataSourceProviderHikariCPSetsInitSQL() {
+        final DataSourceConnectionPoolingType poolingType = DataSourceConnectionPoolingType.HIKARICP;
+
+        DataSourceProvider.DatabaseType databaseType = DataSourceProvider.DatabaseType.H2;
+        boolean shouldUseMariaDB = true;
+
+        final Properties properties = defaultDaoConfigProperties(poolingType, databaseType);
+        properties.put("org.killbill.dao.connectionInitSql", "SELECT 42");
+        final DaoConfig daoConfig = buildDaoConfig(properties);
+
+        final DataSource dataSource = new DataSourceProvider(daoConfig, TEST_POOL, shouldUseMariaDB).get();
+        assertTrue(dataSource instanceof HikariDataSource);
+
+        HikariDataSource hikariDataSource = (HikariDataSource) dataSource;
+        assertEquals("SELECT 42", hikariDataSource.getConnectionInitSql());
+    }
+
+    @Test(groups = "fast")
     public void testDataSourceProviderC3P0() throws Exception {
         for (final DataSourceProvider.DatabaseType databaseType : DataSourceProvider.DatabaseType.values()) {
             for (final boolean shouldUseMariaDB : new boolean[]{false, true}) {

--- a/queue/src/main/java/org/killbill/queue/InTransaction.java
+++ b/queue/src/main/java/org/killbill/queue/InTransaction.java
@@ -84,47 +84,38 @@ public class InTransaction {
             this.connection = connection;
         }
 
-        @Override
         public Connection getConnection() throws SQLException {
             return connection;
         }
 
-        @Override
         public Connection getConnection(final String username, final String password) throws SQLException {
             return connection;
         }
 
-        @Override
         public PrintWriter getLogWriter() throws SQLException {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public void setLogWriter(final PrintWriter out) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public void setLoginTimeout(final int seconds) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public int getLoginTimeout() throws SQLException {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public <T> T unwrap(final Class<T> iface) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public boolean isWrapperFor(final Class<?> iface) throws SQLException {
             throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
mostly need a fix for #8 and the ability to set connection init SQL (mostly for the osgi pool)
... also removed BoneCP (not really production ready) - best to avoid

p.s. C3P0 might need to be updated to 0.9.5 for the init SQL to work

**TODO** update master pom dependencies - C3P0 (0.9.5 final), HikariCP and remove BoneCP