### PR TITLE
@TimedResource metrics

### DIFF
--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>killbill-commons</artifactId>
+        <groupId>org.kill-bill.commons</groupId>
+        <version>0.9-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>killbill-metrics</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics/src/main/java/org/killbill/commons/metrics/MetricTag.java
+++ b/metrics/src/main/java/org/killbill/commons/metrics/MetricTag.java
@@ -19,7 +19,6 @@ package org.killbill.commons.metrics;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.function.Function;
 
 import static java.lang.annotation.ElementType.PARAMETER;
 

--- a/metrics/src/main/java/org/killbill/commons/metrics/MetricTag.java
+++ b/metrics/src/main/java/org/killbill/commons/metrics/MetricTag.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.metrics;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.function.Function;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+
+/**
+ * This annotation can be used to add tags to your resource metrics based on the value of parameters
+ * passed into the resource action.
+ * <code>
+ *     @TimedResource
+ *     public Response create(@MetricTag(tag = "type") String type)
+ *
+ *     @TimedResource
+ *     public Response create(@MetricTag(tag = "type", property="paymentType") Payment type)
+ * </code>
+ *
+ * @see TimedResource
+ */
+@Target(PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MetricTag {
+    /**
+     * Name of the tag.
+     */
+    String tag();
+
+    /**
+     * Optional property name from which the value of tag will be extracted
+     */
+    String property() default "";
+}

--- a/metrics/src/main/java/org/killbill/commons/metrics/TimedResource.java
+++ b/metrics/src/main/java/org/killbill/commons/metrics/TimedResource.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package org.killbill.commons.skeleton.metrics;
+package org.killbill.commons.metrics;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -26,27 +26,32 @@ import java.lang.annotation.Target;
  * <p/>
  * Given a method like this:
  * <code><pre>
- *     &#64;TimedResource(name = "fancyName", rateUnit = TimeUnit.SECONDS, durationUnit = TimeUnit.MICROSECONDS)
- *     public String getStuff() &#123;
+ *     &#64;TimedResource(name = "fancyName")
+ *     public Response create() &#123;
  *         return "Sir Captain " + name;
  *     &#125;
  * </pre></code>
  * <p/>
- * One timer for each response code for the defining class with the name {@code getStuff-[responseCode]}
- * will be created and each time the {@code #getStuff()} method is invoked, the
- * method's execution will be timed.
+ * A timer metric will be created for each response code returned by the method during runtime. Metrics will also be
+ * grouped be the response code (2xx, 3xx, etc). Both rate and latency metrics will be provided.
+ * <p/>
+ * The generated metric name uses the provided name in the annotation or the method name, if the latter is omitted:
+ * <pre>
+ *     kb_resource./payments.fancyName.2xx.200
+ *     kb_resource./payments.fancyName.2xx.201
+ * </pre>
+ * Note that the metric naming is affected by other factors, like the resource Path annotation and the presence of
+ * MetricTag annotations in the method's parameters
+ *
+ * @see MetricTag
+ * @see javax.ws.rs.Path
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface TimedResource {
 
     /**
-     * The name of the timer.
+     * The name of the timer. If not provided, the name of the method will be used.
      */
     String name() default "";
-
-    /**
-     * The default status code of the method.
-     */
-    int defaultStatusCode() default 200;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.29</version>
+        <version>0.57</version>
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>skeleton</module>
         <module>xmlloader</module>
         <module>automaton</module>
+        <module>metrics</module>
     </modules>
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-commons.git</connection>
@@ -112,6 +113,11 @@
             <dependency>
                 <groupId>org.kill-bill.commons</groupId>
                 <artifactId>killbill-locker</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kill-bill.commons</groupId>
+                <artifactId>killbill-metrics</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -146,6 +146,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-metrics</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.skife.config</groupId>
             <artifactId>config-magic</artifactId>
             <optional>true</optional>

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey.contribs</groupId>

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -90,6 +90,7 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey.contribs</groupId>

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/ResourceTimer.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/ResourceTimer.java
@@ -30,17 +30,17 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
-public class TimedResourceMetric {
+public class ResourceTimer {
 
-    private static final Logger log = LoggerFactory.getLogger(TimedResourceMetric.class);
+    private static final Logger log = LoggerFactory.getLogger(ResourceTimer.class);
 
     private final int defaultStatusCode;
     private final LoadingCache<Integer, Timer> metrics;
 
-    public TimedResourceMetric(final Future<MetricRegistry> metricsRegistryFuture,
-                               final Class<?> klass,
-                               final String name,
-                               final int defaultStatusCode) {
+    public ResourceTimer(final Future<MetricRegistry> metricsRegistryFuture,
+                         final Class<?> klass,
+                         final String name,
+                         final int defaultStatusCode) {
         this.defaultStatusCode = defaultStatusCode;
         this.metrics = CacheBuilder.newBuilder()
                                    .build(new CacheLoader<Integer, Timer>() {

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/ResourceTimer.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/ResourceTimer.java
@@ -16,21 +16,14 @@
 
 package org.killbill.commons.skeleton.metrics;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import com.google.common.base.Joiner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.google.common.base.Joiner;
 
 public class ResourceTimer {
 
@@ -54,7 +47,7 @@ public class ResourceTimer {
     public void update(int responseStatus, long duration, TimeUnit unit) {
         final String metricName;
         if (tags != null && !tags.isEmpty()) {
-            final String tags = METRIC_NAME_JOINER.join(this.tags.values());
+            final String tags = METRIC_NAME_JOINER.join(getTagsValues());
             metricName = METRIC_NAME_JOINER.join(
                     "kb_resource", resourcePath, name, httpMethod, tags, responseStatusGroup(responseStatus), responseStatus);
         } else {
@@ -64,6 +57,18 @@ public class ResourceTimer {
         // Letting metric registry deal with unique metric creation
         final Timer timer = registry.timer(metricName);
         timer.update(duration, unit);
+    }
+
+    private List<Object> getTagsValues() {
+        final List<Object> values = new ArrayList<Object>(tags.values().size());
+        for (Object value : tags.values()) {
+            if (value != null) {
+                values.add(value);
+            } else {
+                values.add("null");
+            }
+        }
+        return values;
     }
 
     private String responseStatusGroup(int responseStatus) {

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/TimedResourceInterceptor.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/TimedResourceInterceptor.java
@@ -16,11 +16,25 @@
 
 package org.killbill.commons.skeleton.metrics;
 
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import javax.inject.Provider;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
 
+import org.killbill.commons.metrics.MetricTag;
+
+import com.codahale.metrics.MetricRegistry;
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import com.sun.jersey.spi.container.ExceptionMapperContext;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
@@ -29,33 +43,133 @@ import org.aopalliance.intercept.MethodInvocation;
  */
 public class TimedResourceInterceptor implements MethodInterceptor {
 
-    private final TimedResourceMetric timer;
+    private final Provider<GuiceContainer> jerseyContainer;
+    private final Provider<MetricRegistry> metricRegistry;
+    private final String resourcePath;
+    private final String metricName;
+    private String httpMethod;
 
-    public TimedResourceInterceptor(final TimedResourceMetric timer) {
-        this.timer = timer;
+    public TimedResourceInterceptor(Provider<GuiceContainer> jerseyContainer,
+                                    Provider<MetricRegistry> metricRegistry,
+                                    String resourcePath,
+                                    String metricName,
+                                    String httpMethod) {
+        this.jerseyContainer = jerseyContainer;
+        this.metricRegistry = metricRegistry;
+        this.resourcePath = resourcePath;
+        this.metricName = metricName;
+        this.httpMethod = httpMethod;
     }
 
     @Override
     public Object invoke(final MethodInvocation invocation) throws Throwable {
         final long startTime = System.nanoTime();
-        // two ways to get the response code:
-        // * response object is returned
-        // * exception is thrown
-        // * default response code (not sure how to get that ...)
-        Integer status = null;
+        int responseStatus = 0;
+        try {
+            final Object response = invocation.proceed();
+            if (response instanceof Response) {
+                responseStatus = ((Response) response).getStatus();
+            } else if (response == null || response instanceof Void) {
+                responseStatus = Response.Status.NO_CONTENT.getStatusCode();
+            } else {
+                responseStatus = Response.Status.OK.getStatusCode();
+            }
+
+            return response;
+        } catch (WebApplicationException e) {
+            responseStatus = e.getResponse().getStatus();
+
+            throw e;
+        } catch (final Throwable e) {
+            responseStatus = mapException(e);
+
+            throw e;
+        } finally {
+            final long endTime = System.nanoTime();
+
+            final ResourceTimer timer = timer(invocation);
+            timer.update(responseStatus, endTime - startTime, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private int mapException(final Throwable e) throws Exception {
+        final ExceptionMapperContext exceptionMapperContext = jerseyContainer.get().getWebApplication().getExceptionMapperContext();
+        final ExceptionMapper exceptionMapper = exceptionMapperContext.find(e.getClass());
+
+        if (exceptionMapper != null) {
+            return exceptionMapper.toResponse(e).getStatus();
+        }
+        // If there's no mapping for it, assume 500
+        return Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+    }
+
+    private ResourceTimer timer(MethodInvocation invocation) {
+        final Map<String, Object> metricTags = metricTags(invocation);
+
+        return new ResourceTimer(resourcePath, metricName, httpMethod, metricTags, metricRegistry.get());
+    }
+
+    private static Map<String, Object> metricTags(MethodInvocation invocation) {
+        final LinkedHashMap<String, Object> metricTags = new LinkedHashMap<String, Object>();
+        final Method method = invocation.getMethod();
+        for (int i = 0; i < method.getParameterAnnotations().length; i++) {
+            final Annotation[] parameterAnnotations = method.getParameterAnnotations()[i];
+
+            final MetricTag metricTag = findMetricTagAnnotations(parameterAnnotations);
+            if (metricTag != null) {
+                final Object currentArgument = invocation.getArguments()[i];
+                final Object tagValue;
+                if (metricTag.property().trim().isEmpty()) {
+                    tagValue = currentArgument;
+                } else {
+                    tagValue = getProperty(currentArgument, metricTag.property());
+                }
+                metricTags.put(metricTag.tag(), tagValue);
+            }
+        }
+
+        return metricTags;
+    }
+
+    private static MetricTag findMetricTagAnnotations(Annotation[] parameterAnnotations) {
+        for (final Annotation parameterAnnotation : parameterAnnotations) {
+            if (parameterAnnotation instanceof MetricTag) {
+                return (MetricTag) parameterAnnotation;
+            }
+        }
+        return null;
+    }
+
+    private static Object getProperty(Object currentArgument, String property) {
+        if (currentArgument == null) {
+            return null;
+        }
 
         try {
-            final Object result = invocation.proceed();
-
-            if (result instanceof Response) {
-                status = ((Response) result).getStatus();
+            final String[] methodNames = new String[] { "get" + capitalize(property), "is" + capitalize(property), property };
+            Method propertyMethod = null;
+            for (String methodName : methodNames) {
+                try {
+                    propertyMethod = currentArgument.getClass().getMethod(methodName);
+                    break;
+                } catch (NoSuchMethodException e) {}
             }
-            return result;
-        } catch (final WebApplicationException ex) {
-            status = ex.getResponse().getStatus();
-            throw ex;
-        } finally {
-            timer.update(status, System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+            if (propertyMethod == null) {
+                throw handleReadPropertyError(currentArgument, property, null);
+            }
+            return propertyMethod.invoke(currentArgument);
+        } catch (IllegalAccessException e) {
+            throw handleReadPropertyError(currentArgument, property, e);
+        } catch (InvocationTargetException e) {
+            throw handleReadPropertyError(currentArgument, property, e);
         }
+    }
+
+    private static String capitalize(String property) {
+        return property.substring(0, 1).toUpperCase() + property.substring(1);
+    }
+
+    private static IllegalArgumentException handleReadPropertyError(Object object, String property, Exception e) {
+        return new IllegalArgumentException(String.format("Failed to read tag property \"%s\" value from object of type %s", property, object.getClass()), e);
     }
 }

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/TimedResourceInterceptor.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/TimedResourceInterceptor.java
@@ -16,8 +16,6 @@
 
 package org.killbill.commons.skeleton.metrics;
 
-import java.beans.IntrospectionException;
-import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/modules/StatsModule.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/modules/StatsModule.java
@@ -31,6 +31,7 @@ import com.google.inject.matcher.Matchers;
 import com.google.inject.multibindings.Multibinder;
 import com.palominolabs.metrics.guice.MetricsInstrumentationModule;
 import com.palominolabs.metrics.guice.servlet.AdminServletModule;
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 
 public class StatsModule extends AbstractModule {
 
@@ -80,9 +81,9 @@ public class StatsModule extends AbstractModule {
         install(new AdminServletModule(healthCheckUri, metricsUri, pingUri, threadsUri));
 
         // Metrics/Jersey integration
-        final TimedResourceListener listener = new TimedResourceListener();
-        requestInjection(listener);
-        bindListener(Matchers.any(), listener);
+        final TimedResourceListener timedResourceTypeListener =
+                new TimedResourceListener(getProvider(GuiceContainer.class), getProvider(MetricRegistry.class));
+        bindListener(Matchers.any(), timedResourceTypeListener);
     }
 
     @Provides

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/ResourceTimerTest.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/ResourceTimerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.skeleton.metrics;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.collect.ImmutableMap;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "fast")
+public class ResourceTimerTest {
+
+    private static final String RESOURCE_METRICS_PREFIX = "kb_resource";
+
+    private MetricRegistry metricRegistry;
+
+    @BeforeMethod
+    public void setup() {
+        metricRegistry = new MetricRegistry();
+    }
+
+    @Test
+    public void testMetricName() {
+        final String resourcePath = "/1.0/kb/payments";
+        final String resourceName = "getPayment";
+        final String httpMethod = "GET";
+
+        final ResourceTimer resourceTimer = new ResourceTimer(resourcePath, resourceName, httpMethod, null, metricRegistry);
+        resourceTimer.update(200, 1, TimeUnit.MILLISECONDS);
+
+        final String expectedMetricName = expectedMetricName(resourcePath, resourceName, httpMethod, null, "2xx", 200);
+        final Timer timer = (Timer) metricRegistry.getMetrics().get(expectedMetricName);
+        Assert.assertNotNull(timer, "Failed to create metric with expected name");
+        Assert.assertEquals(1, timer.getCount());
+    }
+
+    private String expectedMetricName(String resourcePath, String resourceName, String httpMethod, String tagsValues, String statusGroup, int status) {
+        if (tagsValues == null || tagsValues.trim().isEmpty()) {
+            return String.format("%s.%s.%s.%s.%s.%s", RESOURCE_METRICS_PREFIX, resourcePath, resourceName, httpMethod, statusGroup, status);
+        }
+        return String.format("%s.%s.%s.%s.%s.%s.%s", RESOURCE_METRICS_PREFIX, resourcePath, resourceName, httpMethod, tagsValues, statusGroup, status);
+    }
+
+    @Test
+    public void testMetricNameWithTags() {
+        final String resourcePath = "/1.0/kb/payments";
+        final String resourceName = "create";
+        final String httpMethod = "POST";
+        final Map<String, Object> tags = (Map) ImmutableMap.builder().put("transactionType", "AUTHORIZE").build();
+
+        final ResourceTimer resourceTimer = new ResourceTimer(resourcePath, resourceName, httpMethod, tags, metricRegistry);
+        resourceTimer.update(501, 1, TimeUnit.MILLISECONDS);
+
+        final String expectedMetricName = expectedMetricName(resourcePath, resourceName, httpMethod, "AUTHORIZE", "5xx", 501);
+        final Timer timer = (Timer) metricRegistry.getMetrics().get(expectedMetricName);
+        Assert.assertNotNull(timer, "Failed to create metric with expected name: " + expectedMetricName);
+        Assert.assertEquals(1, timer.getCount());
+    }
+}

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TestResourceTimer.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TestResourceTimer.java
@@ -27,7 +27,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Test(groups = "fast")
-public class ResourceTimerTest {
+public class TestResourceTimer {
 
     private static final String RESOURCE_METRICS_PREFIX = "kb_resource";
 

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TestTimedResourceInterceptor.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TestTimedResourceInterceptor.java
@@ -39,7 +39,7 @@ import com.google.inject.matcher.Matchers;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 
 @Test(groups = "fast")
-public class TimedResourceInterceptorTest {
+public class TestTimedResourceInterceptor {
 
     private MetricRegistry registry;
     private TestResource interceptedResource;

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TimedResourceInterceptorTest.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TimedResourceInterceptorTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.skeleton.metrics;
+
+import java.net.URI;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import com.codahale.metrics.Timer;
+import org.killbill.commons.metrics.MetricTag;
+import org.killbill.commons.metrics.TimedResource;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.matcher.Matchers;
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+
+@Test(groups = "fast")
+public class TimedResourceInterceptorTest {
+
+    private MetricRegistry registry;
+    private TestResource interceptedResource;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        final Injector injector = Guice.createInjector(new TestResourceModule());
+        registry = injector.getInstance(MetricRegistry.class);
+        interceptedResource = injector.getInstance(TestResource.class);
+    }
+
+    public void testResourceWithResponse() {
+        final Response response = interceptedResource.createOk();
+        Assert.assertEquals(200,  response.getStatus());
+
+        final Timer timer = registry.getTimers().get("kb_resource.path.createOk.POST.2xx.200");
+        Assert.assertNotNull(timer);
+        Assert.assertEquals(1, timer.getCount());
+    }
+
+    public void testResourceSimpleTag() {
+        final Response response = interceptedResource.createOk("AUTHORIZE");
+        Assert.assertEquals(200, response.getStatus());
+
+        final Timer timer = registry.getTimers().get("kb_resource.path.createOk.POST.AUTHORIZE.2xx.200");
+        Assert.assertNotNull(timer);
+        Assert.assertEquals(1, timer.getCount());
+    }
+
+    public void testResourceWithPropertyTag() {
+        final Response response = interceptedResource.createOk(new Payment("PURCHASE"));
+        Assert.assertEquals(201, response.getStatus());
+
+        final Timer timer = registry.getTimers().get("kb_resource.path.createOk.POST.PURCHASE.2xx.201");
+        Assert.assertNotNull(timer);
+        Assert.assertEquals(1, timer.getCount());
+    }
+
+    public void testResourceWithNullResponse() {
+        final Response response = interceptedResource.createNullResponse();
+        Assert.assertNull(response);
+
+        final Timer timer = registry.getTimers().get("kb_resource.path.createNullResponse.PUT.2xx.204");
+        Assert.assertNotNull(timer);
+        Assert.assertEquals(1, timer.getCount());
+    }
+
+    public void testResourceWithVoidResponse() {
+        interceptedResource.createNullResponse();
+
+        final Timer timer = registry.getTimers().get("kb_resource.path.createNullResponse.PUT.2xx.204");
+        Assert.assertNotNull(timer);
+        Assert.assertEquals(1, timer.getCount());
+    }
+
+    public void testResourceWithWebApplicationException() {
+        try {
+            interceptedResource.createWebApplicationException();
+            Assert.fail();
+        } catch(WebApplicationException e) {
+            final Timer timer = registry.getTimers().get("kb_resource.path.createWebApplicationException.POST.4xx.404");
+            Assert.assertNotNull(timer);
+            Assert.assertEquals(1, timer.getCount());
+        }
+    }
+
+    public static class Payment {
+        private final String type;
+
+        public Payment(String type) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+    }
+
+    @Path("path")
+    public static class TestResource {
+
+        @TimedResource
+        @POST
+        public Response createOk() {
+            return Response.ok().build();
+        }
+
+        @TimedResource
+        @POST
+        public Response createOk(@MetricTag(tag = "transactionType") String type) {
+            return Response.ok().build();
+        }
+
+        @TimedResource
+        @POST
+        public Response createOk(@MetricTag(tag = "transactionType", property = "type") Payment payment) {
+            return Response.created(URI.create("about:blank")).build();
+        }
+
+        @TimedResource
+        @PUT
+        public Response createNullResponse() {
+            return null;
+        }
+
+        @TimedResource
+        @PUT
+        public void createVoidResponse() {
+        }
+
+        @TimedResource
+        @POST
+        public void createWebApplicationException() {
+            throw new WebApplicationException(404);
+        }
+    }
+
+    public static class TestResourceModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(GuiceContainer.class);
+            bind(TestResource.class).asEagerSingleton();
+            bind(MetricRegistry.class).asEagerSingleton();
+
+            final TimedResourceListener timedResourceTypeListener =
+                    new TimedResourceListener(getProvider(GuiceContainer.class), getProvider(MetricRegistry.class));
+            bindListener(Matchers.any(), timedResourceTypeListener);
+        }
+    }
+}

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TimedResourceInterceptorTest.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TimedResourceInterceptorTest.java
@@ -78,6 +78,24 @@ public class TimedResourceInterceptorTest {
         Assert.assertEquals(1, timer.getCount());
     }
 
+    public void testResourceNullTag() {
+        final Response response = interceptedResource.createOk((String) null);
+        Assert.assertEquals(200, response.getStatus());
+
+        final Timer timer = registry.getTimers().get("kb_resource.path.createOk.POST.null.2xx.200");
+        Assert.assertNotNull(timer);
+        Assert.assertEquals(1, timer.getCount());
+    }
+
+    public void testResourceNullPropertyTag() {
+        final Response response = interceptedResource.createOk((Payment) null);
+        Assert.assertEquals(201, response.getStatus());
+
+        final Timer timer = registry.getTimers().get("kb_resource.path.createOk.POST.null.2xx.201");
+        Assert.assertNotNull(timer);
+        Assert.assertEquals(1, timer.getCount());
+    }
+
     public void testResourceWithNullResponse() {
         final Response response = interceptedResource.createNullResponse();
         Assert.assertNull(response);


### PR DESCRIPTION
Intercept resources with `@TimedResource` annotation and time execution.
Creates a timer metric for annotated resource method with the following dimensions:
* Resource Path (from @Path annotation on the class)
* Name (either from the @TimedResource annotation or from the method name)
* Tags (from parameters annotated with @MetricTag)
* Http Method
* Response status group (2xx, 3xx, etc)

The unit tests cover the Guice Listener for creating interceptors and the Interceptor itself.

Here's an example of a generated metric name: `kb_resource./1.0/kb/accounts.getAccountByKey.GET.4xx.404`

Right now, this is different from the plugin generated metrics, since it doesn't have the `killbill-service` prefix, so this is something we could add to keep things consistent:
`killbill-service.kb_plugin_errors.killbill-adyen.PaymentPluginApi.getPaymentInfo`

Eventually, we should try consolidating the metric generation/naming in the `metrics` module, so it will be easier to manage this.

This PR is part of https://github.com/killbill/killbill/issues/385