### PR TITLE
Support unpooled database connections

### DIFF
--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -148,6 +148,10 @@
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-embeddeddb-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-embeddeddb-h2</artifactId>
             <scope>test</scope>
         </dependency>

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceConnectionPoolingType.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceConnectionPoolingType.java
@@ -20,5 +20,6 @@ package org.killbill.commons.jdbi.guice;
 
 public enum DataSourceConnectionPoolingType {
     C3P0,
-    HIKARICP
+    HIKARICP,
+    NONE
 }

--- a/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
+++ b/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
@@ -43,6 +43,10 @@ import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.killbill.commons.embeddeddb.EmbeddedDB;
+import org.killbill.commons.embeddeddb.GenericStandaloneDB;
+import org.killbill.commons.embeddeddb.h2.H2EmbeddedDB;
 import org.skife.config.ConfigurationObjectFactory;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -51,6 +55,7 @@ import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.zaxxer.hikari.HikariDataSource;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class TestDataSourceProvider {
@@ -58,6 +63,34 @@ public class TestDataSourceProvider {
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(TestDataSourceProvider.class);
 
     private static final String TEST_POOL_PREFIX = "test-pool";
+
+    @Test(groups = "fast")
+    public void testDataSourceProviderNoPooling() throws Exception {
+        DataSourceProvider.DatabaseType databaseType;
+        DaoConfig daoConfig;
+        String poolName;
+        DataSourceProvider dataSourceProvider;
+
+        // H2
+        databaseType = DataSourceProvider.DatabaseType.H2;
+        daoConfig = buildDaoConfig(DataSourceConnectionPoolingType.NONE, databaseType);
+
+        poolName = TEST_POOL_PREFIX + "-nopool-" + databaseType;
+        dataSourceProvider = new DataSourceProvider(daoConfig, poolName);
+        dataSourceProvider.setEmbeddedDB(new H2EmbeddedDB());
+
+        assertTrue(dataSourceProvider.get() instanceof JdbcConnectionPool);
+
+        // Generic
+        databaseType = DataSourceProvider.DatabaseType.GENERIC;
+        daoConfig = buildDaoConfig(DataSourceConnectionPoolingType.NONE, databaseType);
+
+        poolName = TEST_POOL_PREFIX + "-nopool-" + databaseType;
+        dataSourceProvider = new DataSourceProvider(daoConfig, poolName);
+        dataSourceProvider.setEmbeddedDB(new GenericStandaloneDB(null, null, null, null));
+
+        assertNull(dataSourceProvider.get());
+    }
 
     @Test(groups = "fast")
     public void testDataSourceProviderHikariCP() throws Exception {


### PR DESCRIPTION
Currently, Kill Bill supports the use of either [c3p0](http://www.mchange.com/projects/c3p0/) or [HikariCP](https://brettwooldridge.github.io/HikariCP/) for pooling database connections. In either case, database connections are managed by software running in the same JVM that Kill Bill is
running in.

It would be nice to have the option of configuring Kill Bill so that it doesn't try to pool database connections. This would make it easier to use external database connection pools like [PGBouncer](http://pgbouncer.github.io/).

See also [killbill-platform pull request 18](https://github.com/killbill/killbill-platform/pull/18).