### PR TITLE
Update queries to be compatible with Postgres

### DIFF
--- a/queue/src/main/resources/org/killbill/bus/dao/PersistentBusSqlDao.sql.stg
+++ b/queue/src/main/resources/org/killbill/bus/dao/PersistentBusSqlDao.sql.stg
@@ -38,7 +38,7 @@ getReadyQueueEntriesForSearchKey2(tableName) ::= <<
     from <tableName>
     where
           processing_state = 'AVAILABLE'
-      and created_date \< coalesce(:maxCreatedDate, '2100-01-01')
+      and created_date \< cast(coalesce(:maxCreatedDate, '2100-01-01') as datetime)
       and search_key2 = :searchKey2
     order by
       <readyOrderByClause()>
@@ -64,7 +64,7 @@ getReadyOrInProcessingQueueEntriesForSearchKey2(tableName) ::= <<
     from <tableName>
     where
           processing_state in ('AVAILABLE', 'IN_PROCESSING')
-      and created_date \< coalesce(:maxCreatedDate, '2100-01-01')
+      and created_date \< cast(coalesce(:maxCreatedDate, '2100-01-01') as datetime)
       and search_key2 = :searchKey2
     order by
       <readyOrderByClause()>
@@ -87,7 +87,7 @@ getHistoricalQueueEntriesForSearchKey2(historyTableName) ::= <<
     select
       <allTableFields()>
     from <historyTableName>
-    where created_date >= coalesce(:minCreatedDate, '1970-01-01')
+    where created_date >= cast(coalesce(:minCreatedDate, '1970-01-01') as datetime)
       and search_key2 = :searchKey2
     order by
       <readyOrderByClause()>

--- a/queue/src/main/resources/org/killbill/notificationq/dao/NotificationSqlDao.sql.stg
+++ b/queue/src/main/resources/org/killbill/notificationq/dao/NotificationSqlDao.sql.stg
@@ -49,7 +49,7 @@ getReadyQueueEntriesForSearchKey2(tableName) ::= <<
     where
       queue_name = :queueName
       and processing_state = 'AVAILABLE'
-      and effective_date \< coalesce(:maxEffectiveDate, '2100-01-01')
+      and effective_date \< cast(coalesce(:maxEffectiveDate, '2100-01-01') as datetime)
       and search_key2 = :searchKey2
     order by
       <readyOrderByClause()>
@@ -77,7 +77,7 @@ getReadyOrInProcessingQueueEntriesForSearchKey2(tableName) ::= <<
     where
       queue_name = :queueName
       and processing_state in ('AVAILABLE', 'IN_PROCESSING')
-      and effective_date \< coalesce(:maxEffectiveDate, '2100-01-01')
+      and effective_date \< cast(coalesce(:maxEffectiveDate, '2100-01-01') as datetime)
       and search_key2 = :searchKey2
     order by
       <readyOrderByClause()>
@@ -103,7 +103,7 @@ getHistoricalQueueEntriesForSearchKey2(historyTableName) ::= <<
     from <historyTableName>
     where
           queue_name = :queueName
-      and effective_date >= coalesce(:minEffectiveDate, '1970-01-01')
+      and effective_date >= cast(coalesce(:minEffectiveDate, '1970-01-01') as datetime)
       and search_key2 = :searchKey2
     order by
       <readyOrderByClause()>


### PR DESCRIPTION
Updates to queries in https://github.com/killbill/killbill/issues/703 cause an exception when running against PostgreSQL: `operator does not exist: datetime < text`.  Consider the following behavior under PostgreSQL 9.6.

```
CREATE DOMAIN datetime AS timestamp without time zone;

CREATE TABLE test_table (datetime_value DATETIME);
```

The definition of datetime is from the bridge at https://github.com/killbill/killbill/blob/master/util/src/main/resources/org/killbill/billing/util/ddl-postgresql.sql.

Under some conditions PostgreSQL will perform an implicit conversion between text and dates.  This statement will execute successfully:

```
SELECT * FROM test_table WHERE datetime_value < '2100-01-01';
```

These statements however will throw `operator does not exist`:

```
SELECT * FROM test_table WHERE datetime_value < COALESCE(NULL, '2100-01-01');

SELECT * FROM test_table WHERE datetime_value < COALESCE('2017-04-10', '2100-01-01');
```

Rewriting the queries to this form will execute successfully:

```
SELECT * FROM test_table WHERE datetime_value < CAST(COALESCE(NULL, '2100-01-01') AS DATETIME);

SELECT * FROM test_table WHERE datetime_value < CAST(COALESCE('2017-04-10', '2100-01-01') AS DATETIME);
```

I see both MySQL and PostgreSQL treating CAST(COALESCE()) as deterministic in their execution plans.
