### PR TITLE
jdbi: add new config property org.killbill.dao.initializationFailFast

### DIFF
--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
@@ -132,4 +132,9 @@ public interface DaoConfig {
     @Config("org.killbill.dao.healthCheckExpected99thPercentile")
     @Default("50ms")
     TimeSpan getHealthCheckExpected99thPercentile();
+
+    @Description("Whether or not initialization should fail on error immediately")
+    @Config("org.killbill.dao.initializationFailFast")
+    @Default("false")
+    boolean isInitializationFailFast();
 }


### PR DESCRIPTION
By default, HikariCP shuts down the pool if it encounters an error during initialization.
Guice swallows this error, Kill Bill stops its startup sequence and no information is returned to the user.

This patch introduces a new config property to control this behavior and changes the default:

* If false (new default), the startup sequence continues. Subsequent attempts to retrieve a connection through `HikariDataSource.getConnection` will log an exception if any (the Kill Bill startup sequence continues nonetheless)
* If true (previous behavior), the connection exception is now logged but Guice swallows it and Kill Bill stops its startup sequence

This new default should help debug connectivity issues when provisioning cloud environments.

@sbrossie Could you test this patch to see if it either works around your timing issues or if it helps debug it?