### PR TITLE
jdbi: perf updates

### DIFF
--- a/embeddeddb/common/src/main/java/org/killbill/commons/embeddeddb/EmbeddedDB.java
+++ b/embeddeddb/common/src/main/java/org/killbill/commons/embeddeddb/EmbeddedDB.java
@@ -67,9 +67,9 @@ public abstract class EmbeddedDB {
 
     public abstract DBEngine getDBEngine();
 
-    public abstract void initialize() throws IOException;
+    public abstract void initialize() throws IOException, SQLException;
 
-    public abstract void start() throws IOException;
+    public abstract void start() throws IOException, SQLException;
 
     public abstract void refreshTableNames() throws IOException;
 

--- a/embeddeddb/common/src/main/java/org/killbill/commons/embeddeddb/GenericStandaloneDB.java
+++ b/embeddeddb/common/src/main/java/org/killbill/commons/embeddeddb/GenericStandaloneDB.java
@@ -17,6 +17,7 @@
 package org.killbill.commons.embeddeddb;
 
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.sql.DataSource;
@@ -35,7 +36,7 @@ public class GenericStandaloneDB extends EmbeddedDB {
     }
 
     @Override
-    public void initialize() throws IOException {
+    public void initialize() throws IOException, SQLException {
     }
 
     @Override

--- a/embeddeddb/mysql/pom.xml
+++ b/embeddeddb/mysql/pom.xml
@@ -28,6 +28,10 @@
     <name>Kill Bill library of embedded dbs: MySQL</name>
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>

--- a/embeddeddb/mysql/src/main/java/org/killbill/commons/embeddeddb/mysql/KillBillMariaDbDataSource.java
+++ b/embeddeddb/mysql/src/main/java/org/killbill/commons/embeddeddb/mysql/KillBillMariaDbDataSource.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.embeddeddb.mysql;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.mariadb.jdbc.MariaDbDataSource;
+import org.mariadb.jdbc.UrlParser;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+
+public class KillBillMariaDbDataSource extends MariaDbDataSource {
+
+    private static final Joiner.MapJoiner mapJoiner = Joiner.on('&').withKeyValueSeparator("=");
+
+    private String url;
+
+    private Boolean cachePrepStmts;
+    private Integer prepStmtCacheSize;
+    private Integer prepStmtCacheSqlLimit;
+    private Boolean useServerPrepStmts;
+
+    @Override
+    public void setUrl(final String url) throws SQLException {
+        this.url = url;
+        super.setUrl(url);
+    }
+
+    // See HikariDataSourceBuilder and https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
+
+    public void setCachePrepStmts(final boolean cachePrepStmts) throws SQLException {
+        this.cachePrepStmts = cachePrepStmts;
+        updateUrlIfNeeded();
+    }
+
+    public void setPrepStmtCacheSize(final int prepStmtCacheSize) throws SQLException {
+        this.prepStmtCacheSize = prepStmtCacheSize;
+        updateUrlIfNeeded();
+    }
+
+    public void setPrepStmtCacheSqlLimit(final int prepStmtCacheSqlLimit) throws SQLException {
+        this.prepStmtCacheSqlLimit = prepStmtCacheSqlLimit;
+        updateUrlIfNeeded();
+    }
+
+    // Note! New default is now false (was true before 1.6.0)
+    public void setUseServerPrepStmts(final boolean useServerPrepStmts) throws SQLException {
+        this.useServerPrepStmts = useServerPrepStmts;
+        updateUrlIfNeeded();
+    }
+
+    private void updateUrlIfNeeded() throws SQLException {
+        if (url == null) {
+            final UrlParser urlParser = getUrlParser();
+            if (urlParser != null) {
+                url = urlParser.getInitialUrl();
+            }
+        }
+
+        if (url != null) {
+            setUrl(buildUpdatedUrl(url));
+        }
+    }
+
+    // No easy way to set MariaDB options at runtime besides updating the JDBC url
+    @VisibleForTesting
+    String buildUpdatedUrl(final String url) throws SQLException {
+        final Properties props = new Properties();
+        UrlParser.parse(url, props);
+        if (cachePrepStmts != null && !props.containsKey("cachePrepStmts")) {
+            props.put("cachePrepStmts", cachePrepStmts);
+        }
+        if (prepStmtCacheSize != null && !props.containsKey("prepStmtCacheSize")) {
+            props.put("prepStmtCacheSize", prepStmtCacheSize);
+        }
+        if (prepStmtCacheSqlLimit != null && !props.containsKey("prepStmtCacheSqlLimit")) {
+            props.put("prepStmtCacheSqlLimit", prepStmtCacheSqlLimit);
+        }
+        if (useServerPrepStmts != null && !props.containsKey("useServerPrepStmts")) {
+            props.put("useServerPrepStmts", useServerPrepStmts);
+        }
+
+        final int separator = url.indexOf("//");
+        final String urlSecondPart = url.substring(separator + 2);
+        final int paramIndex = urlSecondPart.indexOf("?");
+
+        final String baseUrl = paramIndex > 0 ? url.substring(0, separator + 2 + paramIndex) : url;
+        return props.isEmpty() ? baseUrl : baseUrl + "?" + mapJoiner.join(props);
+    }
+
+    @VisibleForTesting
+    public UrlParser initializeAndGetUrlParser() throws SQLException {
+        super.initialize();
+        return super.getUrlParser();
+    }
+}

--- a/embeddeddb/mysql/src/main/java/org/killbill/commons/embeddeddb/mysql/MySQLStandaloneDB.java
+++ b/embeddeddb/mysql/src/main/java/org/killbill/commons/embeddeddb/mysql/MySQLStandaloneDB.java
@@ -62,7 +62,7 @@ public class MySQLStandaloneDB extends GenericStandaloneDB {
     }
 
     @Override
-    public void initialize() throws IOException {
+    public void initialize() throws IOException, SQLException {
         super.initialize();
 
         if (useMariaDB) {

--- a/embeddeddb/mysql/src/test/java/org/killbill/commons/embeddeddb/mysql/MySQLEmbeddedDB.java
+++ b/embeddeddb/mysql/src/test/java/org/killbill/commons/embeddeddb/mysql/MySQLEmbeddedDB.java
@@ -72,7 +72,7 @@ public class MySQLEmbeddedDB extends EmbeddedDB {
     }
 
     @Override
-    public void start() throws IOException {
+    public void start() throws IOException, SQLException {
         if (started.get()) {
             throw new IOException("MySQL is already running: " + jdbcConnectionString);
         }
@@ -124,7 +124,7 @@ public class MySQLEmbeddedDB extends EmbeddedDB {
         return String.format("mysql -u%s -p%s -P%s -S%s/mysql.sock %s", username, password, port, dataDir, databaseName);
     }
 
-    protected void createDataSource() throws IOException {
+    protected void createDataSource() throws IOException, SQLException {
         if (useConnectionPooling()) {
             dataSource = createHikariDataSource();
         } else {

--- a/embeddeddb/mysql/src/test/java/org/killbill/commons/embeddeddb/mysql/TestKillBillMariaDbDataSource.java
+++ b/embeddeddb/mysql/src/test/java/org/killbill/commons/embeddeddb/mysql/TestKillBillMariaDbDataSource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.embeddeddb.mysql;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestKillBillMariaDbDataSource {
+
+    @Test(groups = "fast")
+    public void testUpdateUrl() throws Exception {
+        final KillBillMariaDbDataSource killBillMariaDbDataSource = new KillBillMariaDbDataSource();
+
+        Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false"),
+                            "jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false");
+        Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill"),
+                            "jdbc:mysql://127.0.0.1:3306/killbill");
+
+        killBillMariaDbDataSource.setCachePrepStmts(false);
+        Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false"),
+                            "jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false");
+        Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill"),
+                            "jdbc:mysql://127.0.0.1:3306/killbill?cachePrepStmts=false");
+
+        killBillMariaDbDataSource.setCachePrepStmts(true);
+        Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false"),
+                            "jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false");
+        Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill"),
+                            "jdbc:mysql://127.0.0.1:3306/killbill?cachePrepStmts=true");
+
+        killBillMariaDbDataSource.setPrepStmtCacheSize(123);
+        Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false"),
+                            "jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false&prepStmtCacheSize=123");
+        Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill"),
+                            "jdbc:mysql://127.0.0.1:3306/killbill?cachePrepStmts=true&prepStmtCacheSize=123");
+    }
+}

--- a/embeddeddb/postgresql/src/main/java/org/killbill/commons/embeddeddb/postgresql/PostgreSQLStandaloneDB.java
+++ b/embeddeddb/postgresql/src/main/java/org/killbill/commons/embeddeddb/postgresql/PostgreSQLStandaloneDB.java
@@ -50,7 +50,7 @@ public class PostgreSQLStandaloneDB extends GenericStandaloneDB {
     }
 
     @Override
-    public void initialize() throws IOException {
+    public void initialize() throws IOException, SQLException {
         super.initialize();
         dataSource = new PGSimpleDataSource();
         ((PGSimpleDataSource) dataSource).setDatabaseName(databaseName);

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -160,6 +160,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-embeddeddb-mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <scope>test</scope>

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
@@ -115,7 +115,7 @@ public interface DaoConfig {
 
     @Description("MySQL server version")
     @Config("org.killbill.dao.mysqlServerVersion")
-    @Default("4.0")
+    @Default("5.1")
     String getMySQLServerVersion();
 
     @Description("Log level for SQL queries")

--- a/jdbi/src/main/java/org/skife/jdbi/v2/DBI.java
+++ b/jdbi/src/main/java/org/skife/jdbi/v2/DBI.java
@@ -212,6 +212,11 @@ public class DBI implements IDBI
     @Override
     public Handle open()
     {
+        return open(connectionFactory);
+    }
+
+    public Handle open(final ConnectionFactory connectionFactory)
+    {
         try {
             final long start = System.nanoTime();
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.141.34</version>
+        <version>0.141.36</version>
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>

--- a/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
+++ b/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2017 Groupon, Inc
- * Copyright 2014-2017 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -54,6 +54,7 @@ import org.killbill.queue.dispatching.BlockingRejectionExecutionHandler;
 import org.killbill.queue.dispatching.CallableCallbackBase;
 import org.killbill.queue.dispatching.Dispatcher;
 import org.skife.config.ConfigurationObjectFactory;
+import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +70,8 @@ import com.google.common.eventbus.EventBusThatThrowsException;
 public class DefaultPersistentBus extends DefaultQueueLifecycle implements PersistentBus {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultPersistentBus.class);
+
+    private final DBI dbi;
     private final EventBusThatThrowsException eventBusDelegate;
     private final DBBackedQueue<BusEventModelDao> dao;
     private final Clock clock;
@@ -89,6 +92,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
     @Inject
     public DefaultPersistentBus(@Named(QUEUE_NAME) final IDBI dbi, final Clock clock, final PersistentBusConfig config, final MetricRegistry metricRegistry, final DatabaseTransactionNotificationApi databaseTransactionNotificationApi) {
         super("Bus", config);
+        this.dbi = (DBI) dbi;
         final PersistentBusSqlDao sqlDao = dbi.onDemand(PersistentBusSqlDao.class);
         this.clock = clock;
         this.config = config;
@@ -227,7 +231,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
             }
         };
 
-        InTransaction.execute(connection, handler, PersistentBusSqlDao.class);
+        InTransaction.execute(dbi, connection, handler, PersistentBusSqlDao.class);
     }
 
     @Override
@@ -243,7 +247,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
                 return getAvailableBusEventsForSearchKeysInternal(transactional, null, searchKey1, searchKey2);
             }
         };
-        return InTransaction.execute(connection, handler, PersistentBusSqlDao.class);
+        return InTransaction.execute(dbi, connection, handler, PersistentBusSqlDao.class);
     }
 
     @Override
@@ -259,7 +263,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
                 return getAvailableBusEventsForSearchKeysInternal(transactional, maxCreatedDate, null, searchKey2);
             }
         };
-        return InTransaction.execute(connection, handler, PersistentBusSqlDao.class);
+        return InTransaction.execute(dbi, connection, handler, PersistentBusSqlDao.class);
     }
 
     @Override
@@ -280,7 +284,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
                 return getAvailableOrInProcessingBusEventsForSearchKeysInternal(transactional, null, searchKey1, searchKey2);
             }
         };
-        return InTransaction.execute(connection, handler, PersistentBusSqlDao.class);
+        return InTransaction.execute(dbi, connection, handler, PersistentBusSqlDao.class);
     }
 
     @Override
@@ -296,7 +300,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
                 return getAvailableOrInProcessingBusEventsForSearchKeysInternal(transactional, maxCreatedDate, null, searchKey2);
             }
         };
-        return InTransaction.execute(connection, handler, PersistentBusSqlDao.class);
+        return InTransaction.execute(dbi, connection, handler, PersistentBusSqlDao.class);
     }
 
     @Override

--- a/queue/src/main/java/org/killbill/notificationq/DefaultNotificationQueue.java
+++ b/queue/src/main/java/org/killbill/notificationq/DefaultNotificationQueue.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2011 Ning, Inc.
- * Copyright 2015 Groupon, Inc
- * Copyright 2015 The Billing Project, LLC
+ * Copyright 2015-2018 Groupon, Inc
+ * Copyright 2015-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -43,6 +43,7 @@ import org.killbill.queue.InTransaction;
 import org.killbill.queue.QueueObjectMapper;
 import org.killbill.queue.api.PersistentQueueEntryLifecycleState;
 import org.killbill.queue.dispatching.CallableCallbackBase;
+import org.skife.jdbi.v2.DBI;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
@@ -51,6 +52,7 @@ import com.google.common.collect.Iterables;
 
 public class DefaultNotificationQueue implements NotificationQueue {
 
+    private final DBI dbi;
     private final DBBackedQueue<NotificationEventModelDao> dao;
     private final String svcName;
     private final String queueName;
@@ -64,14 +66,15 @@ public class DefaultNotificationQueue implements NotificationQueue {
     private volatile boolean isStarted;
 
     public DefaultNotificationQueue(final String svcName, final String queueName, final NotificationQueueHandler handler,
-                                    final DBBackedQueue<NotificationEventModelDao> dao, final NotificationQueueService notificationQueueService,
+                                    final DBI dbi, final DBBackedQueue<NotificationEventModelDao> dao, final NotificationQueueService notificationQueueService,
                                     final Clock clock, final NotificationQueueConfig config) {
-        this(svcName, queueName, handler, dao, notificationQueueService, clock, config, QueueObjectMapper.get());
+        this(svcName, queueName, handler, dbi, dao, notificationQueueService, clock, config, QueueObjectMapper.get());
     }
 
     public DefaultNotificationQueue(final String svcName, final String queueName, final NotificationQueueHandler handler,
-                                    final DBBackedQueue<NotificationEventModelDao> dao, final NotificationQueueService notificationQueueService,
+                                    final DBI dbi, final DBBackedQueue<NotificationEventModelDao> dao, final NotificationQueueService notificationQueueService,
                                     final Clock clock, final NotificationQueueConfig config, final ObjectMapper objectMapper) {
+        this.dbi = dbi;
         this.svcName = svcName;
         this.queueName = queueName;
         this.handler = handler;
@@ -107,7 +110,7 @@ public class DefaultNotificationQueue implements NotificationQueue {
                 return null;
             }
         };
-        InTransaction.execute(connection, handler, NotificationSqlDao.class);
+        InTransaction.execute(dbi, connection, handler, NotificationSqlDao.class);
     }
 
     @Override
@@ -134,7 +137,7 @@ public class DefaultNotificationQueue implements NotificationQueue {
                 return null;
             }
         };
-        InTransaction.execute(connection, handler, NotificationSqlDao.class);
+        InTransaction.execute(dbi, connection, handler, NotificationSqlDao.class);
     }
 
 
@@ -152,7 +155,7 @@ public class DefaultNotificationQueue implements NotificationQueue {
                 return getFutureNotificationsInternal(transactional, null, searchKey1, searchKey2);
             }
         };
-        return InTransaction.execute(connection, handler, NotificationSqlDao.class);
+        return InTransaction.execute(dbi, connection, handler, NotificationSqlDao.class);
     }
 
     @Override
@@ -168,7 +171,7 @@ public class DefaultNotificationQueue implements NotificationQueue {
                 return getFutureNotificationsInternal(transactional, maxEffectiveDate, null, searchKey2);
             }
         };
-        return InTransaction.execute(connection, handler, NotificationSqlDao.class);
+        return InTransaction.execute(dbi, connection, handler, NotificationSqlDao.class);
     }
 
     @Override
@@ -189,7 +192,7 @@ public class DefaultNotificationQueue implements NotificationQueue {
                 return getFutureOrInProcessingNotificationsInternal(transactional, null, searchKey1, searchKey2);
             }
         };
-        return InTransaction.execute(connection, handler, NotificationSqlDao.class);
+        return InTransaction.execute(dbi, connection, handler, NotificationSqlDao.class);
     }
 
     @Override
@@ -205,7 +208,7 @@ public class DefaultNotificationQueue implements NotificationQueue {
                 return getFutureOrInProcessingNotificationsInternal(transactional, maxEffectiveDate, null, searchKey2);
             }
         };
-        return InTransaction.execute(connection, handler, NotificationSqlDao.class);
+        return InTransaction.execute(dbi, connection, handler, NotificationSqlDao.class);
     }
 
     @Override
@@ -321,7 +324,7 @@ public class DefaultNotificationQueue implements NotificationQueue {
                 return null;
             }
         };
-        InTransaction.execute(connection, handler, NotificationSqlDao.class);
+        InTransaction.execute(dbi, connection, handler, NotificationSqlDao.class);
     }
 
     @Override


### PR DESCRIPTION
* Make sure DBI caches are used for the queues APIs
* Ensure prepared statements are cached (server-side) by default (regression with recent MariaDB driver upgrade)