### PR TITLE
jdbi: perf updates

### DIFF
--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
@@ -142,4 +142,9 @@ public interface DaoConfig {
     @Config("org.killbill.dao.initializationFailFast")
     @Default("false")
     boolean isInitializationFailFast();
+
+    @Description("Set the default transaction isolation level")
+    @Config("org.killbill.dao.transactionIsolationLevel")
+    @Default("TRANSACTION_READ_COMMITTED")
+    String getTransactionIsolationLevel();
 }

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceProvider.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceProvider.java
@@ -167,6 +167,8 @@ public class DataSourceProvider implements Provider<DataSource> {
             }
             hikariConfig.setInitializationFailFast(config.isInitializationFailFast());
 
+            hikariConfig.setTransactionIsolation(config.getTransactionIsolationLevel());
+
             hikariConfig.setRegisterMbeans(true);
 
             if (metricRegistry != null) {

--- a/jdbi/src/main/java/org/skife/jdbi/v2/Query.java
+++ b/jdbi/src/main/java/org/skife/jdbi/v2/Query.java
@@ -267,7 +267,9 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
     @Override
     public <T> T first(Class<T> containerType)
     {
-        addStatementCustomizer(StatementCustomizers.MAX_ROW_ONE);
+        // Kill Bill specific: assume our queries will always either use LIMIT 1 or will return exactly one row (see ResultReturnThing)
+        // This saves a roundtrip (set @@SQL_SELECT_LIMIT=1)
+        //addStatementCustomizer(StatementCustomizers.MAX_ROW_ONE);
         ContainerBuilder builder = getContainerMapperRegistry().createBuilderFor(containerType);
 
         return (T) this.fold(builder, new Folder3<ContainerBuilder, ResultType>()


### PR DESCRIPTION
* Set the default transaction isolation level at the pool level: this avoids 3 roundtrips (GET, SET, RESET) for each transaction
* Don't call `setMaxRows(1)` for most queries
