### PR TITLE
jdbi: make HikariCP read-only state configurable

### DIFF
--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DaoConfig.java
@@ -147,4 +147,9 @@ public interface DaoConfig {
     @Config("org.killbill.dao.transactionIsolationLevel")
     @Default("TRANSACTION_READ_COMMITTED")
     String getTransactionIsolationLevel();
+
+    @Description("Whether to put connections in read-only mode")
+    @Config("org.killbill.dao.readOnly")
+    @Default("false")
+    boolean isReadOnly();
 }

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceProvider.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DataSourceProvider.java
@@ -1,9 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2017 Groupon, Inc
- * Copyright 2014-2017 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -168,6 +168,8 @@ public class DataSourceProvider implements Provider<DataSource> {
             hikariConfig.setInitializationFailFast(config.isInitializationFailFast());
 
             hikariConfig.setTransactionIsolation(config.getTransactionIsolationLevel());
+
+            hikariConfig.setReadOnly(config.isReadOnly());
 
             hikariConfig.setRegisterMbeans(true);
 


### PR DESCRIPTION
This puts connections in read-only mode as a hint to the driver to enable database optimizations.
