### PR TITLE
queue: create jdbi-shaded artifact

### DIFF
--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -174,4 +174,36 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jdbi-shaded</shadedClassifierName>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.skife.jdbi</pattern>
+                                    <shadedPattern>org.killbill.queue.org.skife.jdbi</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.kill-bill.commons:killbill-jdbi</include>
+                                    <include>org.kill-bill.commons:killbill-queue</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Create an artifact with our forked version of JDBI shaded. That way, projects can depend on it without having to worry about a conflicting JDBI version.

Note: make sure to exclude the killbill-jdbi transitive dependency.
