### PR TITLE
queue: remove usage of LAST_INSERT_ID

### DIFF
--- a/queue/src/main/java/org/killbill/queue/DBBackedQueue.java
+++ b/queue/src/main/java/org/killbill/queue/DBBackedQueue.java
@@ -255,19 +255,17 @@ public abstract class DBBackedQueue<T extends EventEntryModelDao> {
 
             @Override
             public Long execute() throws RuntimeException {
+                final long init = System.nanoTime();
 
-                long init = System.nanoTime();
-
-                // LAST_INSERT_ID is kept at the transaction level; we reset it to 0 so that in case insert fails, we don't end up with a previous
-                // value that would end up corrupting the inflightQ
-                // Note! This is a no-op for H2 (see QueueSqlDao.sql.stg and https://github.com/killbill/killbill/issues/223)
-                transactional.resetLastInsertId();
-                transactional.insertEntry(entry, config.getTableName());
-
-                final Long lastInsertId = transactional.getLastInsertId();
-                log.debug("{} Inserting entry: lastInsertId={}, entry={}", DB_QUEUE_LOG_ID, lastInsertId, entry);
+                final Long lastInsertId = transactional.insertEntry(entry, config.getTableName());
+                if (lastInsertId > 0) {
+                    log.debug("{} Inserting entry: lastInsertId={}, entry={}", DB_QUEUE_LOG_ID, lastInsertId, entry);
+                } else {
+                    log.warn("{} Error inserting entry: lastInsertId={}, entry={}", DB_QUEUE_LOG_ID, lastInsertId, entry);
+                }
 
                 rawInsertEntryTime.update(System.nanoTime() - init, TimeUnit.NANOSECONDS);
+
                 return lastInsertId;
             }
         });

--- a/queue/src/main/java/org/killbill/queue/dao/QueueSqlDao.java
+++ b/queue/src/main/java/org/killbill/queue/dao/QueueSqlDao.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2017 Groupon, Inc
- * Copyright 2014-2017 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.killbill.commons.jdbi.binder.SmartBindBean;
 import org.killbill.commons.jdbi.template.KillBillSqlDaoStringTemplate;
 import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
@@ -35,18 +36,13 @@ import org.skife.jdbi.v2.sqlobject.customizers.Define;
 import org.skife.jdbi.v2.sqlobject.mixins.CloseMe;
 import org.skife.jdbi.v2.sqlobject.mixins.Transactional;
 import org.skife.jdbi.v2.unstable.BindIn;
+import org.skife.jdbi.v2.util.LongMapper;
 
 @KillBillSqlDaoStringTemplate
 public interface QueueSqlDao<T extends EventEntryModelDao> extends Transactional<QueueSqlDao<T>>, CloseMe {
 
     @SqlQuery
     Long getMaxRecordId(@Define("tableName") final String tableName);
-
-    @SqlQuery
-    Long resetLastInsertId();
-
-    @SqlQuery
-    Long getLastInsertId();
 
     @SqlQuery
     T getByRecordId(@Bind("recordId") Long id,
@@ -110,9 +106,9 @@ public interface QueueSqlDao<T extends EventEntryModelDao> extends Transactional
                        @Define("tableName") final String tableName);
 
     @SqlUpdate
-    void insertEntry(@SmartBindBean T evt,
+    @GetGeneratedKeys(value = LongMapper.class, columnName = "record_id")
+    Long insertEntry(@SmartBindBean T evt,
                      @Define("tableName") final String tableName);
-
 
     @SqlBatch
     @BatchChunkSize(100)

--- a/queue/src/main/resources/org/killbill/queue/dao/QueueSqlDao.sql.stg
+++ b/queue/src/main/resources/org/killbill/queue/dao/QueueSqlDao.sql.stg
@@ -104,14 +104,6 @@ getMaxRecordId(tableName) ::= <<
     ;
 >>
 
-resetLastInsertId() ::= <<
-    select LAST_INSERT_ID(/*! 0 */);
->>
-
-getLastInsertId() ::= <<
-    select LAST_INSERT_ID();
->>
-
 getByRecordId(tableName) ::= <<
     select
       <allTableFields()>

--- a/queue/src/test/java/org/killbill/notificationq/dao/TestNotificationSqlDao.java
+++ b/queue/src/test/java/org/killbill/notificationq/dao/TestNotificationSqlDao.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -255,8 +255,8 @@ public class TestNotificationSqlDao extends TestSetup {
         return dao.inTransaction(new Transaction<NotificationEventModelDao, QueueSqlDao<NotificationEventModelDao>>() {
             @Override
             public NotificationEventModelDao inTransaction(final QueueSqlDao<NotificationEventModelDao> transactional, final TransactionStatus status) throws Exception {
-                transactional.insertEntry(input, tableName);
-                return transactional.getByRecordId(transactional.getLastInsertId(), notificationQueueConfig.getTableName());
+                final Long recordId = transactional.insertEntry(input, tableName);
+                return transactional.getByRecordId(recordId, notificationQueueConfig.getTableName());
             }
         });
 


### PR DESCRIPTION
Regarding `insertEntry` failing, I'm not even sure it's possible it would silently fail?