### PR TITLE
queue: Split start sequence into initQueue() and startQueue() for fin…

### DIFF
--- a/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
+++ b/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
@@ -186,10 +186,10 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
     public void stopQueue() {
         if (isStarted.compareAndSet(true, false)) {
             isInitialized.set(false);
-            super.stopQueue();
             reaper.stop();
-            dao.close();
+            super.stopQueue();
             dispatcher.stop();
+            dao.close();
         }
     }
 

--- a/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
+++ b/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
@@ -141,35 +141,55 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
              new MetricRegistry(), new DatabaseTransactionNotificationApi());
     }
 
-    @Override
-    public void start() {
 
+    @Override
+    public boolean initQueue() {
         if (config.isProcessingOff()) {
-            log.warn("PersistentBus processing is off, does not start");
-            return;
+            log.warn("PersistentBus processing is off, cannot be initialized");
+            return false;
         }
 
         if (isInitialized.compareAndSet(false, true)) {
             dao.initialize();
             dispatcher.start();
-            startQueue();
-
-            if (config.getPersistentQueueMode() == PersistentQueueMode.STICKY_POLLING || config.getPersistentQueueMode() == PersistentQueueMode.STICKY_EVENTS) {
-                reaper.start();
-            }
-            isStarted.set(true);
+            return true;
+        } else {
+            return false;
         }
-
     }
 
     @Override
-    public void stop() {
+    public boolean startQueue() {
+
+        if (config.isProcessingOff()) {
+            log.warn("PersistentBus processing is off, cannot be started");
+            return false;
+        }
+
+        if (!isInitialized.get()) {
+            // Make it easy for our tests, so they simply call startQueue
+            initQueue();
+        }
+
+        if (isStarted.compareAndSet(false, true)) {
+            if (config.getPersistentQueueMode() == PersistentQueueMode.STICKY_POLLING || config.getPersistentQueueMode() == PersistentQueueMode.STICKY_EVENTS) {
+                reaper.start();
+            }
+            super.startQueue();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void stopQueue() {
         if (isStarted.compareAndSet(true, false)) {
             isInitialized.set(false);
-            dao.close();
-            stopQueue();
-            dispatcher.stop();
+            super.stopQueue();
             reaper.stop();
+            dao.close();
+            dispatcher.stop();
         }
     }
 
@@ -210,7 +230,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
 
     @Override
     public void register(final Object handlerInstance) throws EventBusException {
-        if (isStarted.get()) {
+        if (isInitialized.get()) {
             eventBusDelegate.register(handlerInstance);
         } else {
             log.warn("Attempting to register handler " + handlerInstance + " in a non initialized bus");
@@ -219,7 +239,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
 
     @Override
     public void unregister(final Object handlerInstance) throws EventBusException {
-        if (isStarted.get()) {
+        if (isInitialized.get()) {
             eventBusDelegate.unregister(handlerInstance);
         } else {
             log.warn("Attempting to unregister handler " + handlerInstance + " in a non initialized bus");
@@ -229,7 +249,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
     @Override
     public void post(final BusEvent event) throws EventBusException {
         try {
-            if (isStarted.get()) {
+            if (isInitialized.get()) {
                 final String json = objectMapper.writeValueAsString(event);
                 final BusEventModelDao entry = new BusEventModelDao(CreatorName.get(), clock.getUTCNow(), event.getClass().getName(), json,
                                                                     event.getUserToken(), event.getSearchKey1(), event.getSearchKey2());
@@ -245,7 +265,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
 
     @Override
     public void postFromTransaction(final BusEvent event, final Connection connection) throws EventBusException {
-        if (!isStarted.get()) {
+        if (!isInitialized.get()) {
             log.warn("Attempting to post event " + event + " in a non initialized bus");
             return;
         }

--- a/queue/src/main/java/org/killbill/bus/InMemoryPersistentBus.java
+++ b/queue/src/main/java/org/killbill/bus/InMemoryPersistentBus.java
@@ -41,14 +41,6 @@ public class InMemoryPersistentBus implements PersistentBus {
     private final EventBusDelegate delegate;
     private final AtomicBoolean isInitialized;
 
-    @Override
-    public boolean startQueue() {
-        return true;
-    }
-
-    @Override
-    public void stopQueue() {
-    }
 
     @Override
     public boolean isStarted() {
@@ -116,10 +108,18 @@ public class InMemoryPersistentBus implements PersistentBus {
     }
 
     @Override
-    public void start() {
+    public boolean initQueue() {
+        return false;
+    }
+
+
+    @Override
+    public boolean startQueue() {
         if (isInitialized.compareAndSet(false, true)) {
             log.info("InMemoryPersistentBus started...");
-
+            return true;
+        } else {
+            return false;
         }
     }
 
@@ -131,7 +131,7 @@ public class InMemoryPersistentBus implements PersistentBus {
     }
 
     @Override
-    public void stop() {
+    public void stopQueue() {
         if (isInitialized.compareAndSet(true, false)) {
             log.info("InMemoryPersistentBus stopping...");
             delegate.completeDispatch();

--- a/queue/src/main/java/org/killbill/bus/api/PersistentBus.java
+++ b/queue/src/main/java/org/killbill/bus/api/PersistentBus.java
@@ -51,15 +51,6 @@ public interface PersistentBus extends QueueLifecycle {
         }
     }
 
-    /**
-     * Start accepting events and dispatching them
-     */
-    void start();
-
-    /**
-     * Stop accepting events and flush event queue before it returns.
-     */
-    void stop();
 
     /**
      * Registers all handler methods on {@code object} to receive events.

--- a/queue/src/main/java/org/killbill/notificationq/DefaultNotificationQueue.java
+++ b/queue/src/main/java/org/killbill/notificationq/DefaultNotificationQueue.java
@@ -416,6 +416,7 @@ public class DefaultNotificationQueue implements NotificationQueue {
     @Override
     public boolean startQueue() {
         if (config.isProcessingOff()) {
+            logger.warn("Not starting queue {} because of xxx.notification.off config", getFullQName());
             return false;
         }
 

--- a/queue/src/main/java/org/killbill/notificationq/NotificationQueueDispatcher.java
+++ b/queue/src/main/java/org/killbill/notificationq/NotificationQueueDispatcher.java
@@ -158,7 +158,6 @@ public class NotificationQueueDispatcher extends DefaultQueueLifecycle {
                 return false;
             }
         }
-
     }
 
     @Override
@@ -170,9 +169,10 @@ public class NotificationQueueDispatcher extends DefaultQueueLifecycle {
             //
             if (activeQueues == 0) {
                 isInitialized.set(false);
-                super.stopQueue();
                 reaper.stop();
+                super.stopQueue();
                 dispatcher.stop();
+                dao.close();
                 isStarted = false;
             }
         }

--- a/queue/src/main/java/org/killbill/notificationq/NotificationQueueDispatcher.java
+++ b/queue/src/main/java/org/killbill/notificationq/NotificationQueueDispatcher.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.joda.time.DateTime;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
 import org.killbill.notificationq.api.NotificationQueue;
@@ -52,7 +51,6 @@ import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 
@@ -74,7 +72,10 @@ public class NotificationQueueDispatcher extends DefaultQueueLifecycle {
 
     // We could event have one per queue is required...
     private final Dispatcher<NotificationEvent, NotificationEventModelDao> dispatcher;
-    private final AtomicBoolean isStarted;
+    private final AtomicBoolean isInitialized;
+
+    private volatile boolean isStarted;
+    private volatile int activeQueues;
 
     private final NotificationCallableCallback notificationCallableCallback;
 
@@ -108,7 +109,10 @@ public class NotificationQueueDispatcher extends DefaultQueueLifecycle {
         this.perQueueProcessingTime = new HashMap<String, Histogram>();
 
         this.metricRegistry = metricRegistry;
-        this.isStarted = new AtomicBoolean(false);
+        this.isInitialized = new AtomicBoolean(false);
+        this.isStarted = false;
+        this.activeQueues = 0;
+
         this.reaper = new NotificationReaper(this.dao, config, clock);
 
         this.notificationCallableCallback = new NotificationCallableCallback(this);
@@ -117,50 +121,66 @@ public class NotificationQueueDispatcher extends DefaultQueueLifecycle {
     }
 
     @Override
-    public boolean startQueue() {
-        if (isStarted.compareAndSet(false, true)) {
+    public boolean initQueue() {
+        if (isInitialized.compareAndSet(false, true)) {
             dao.initialize();
             dispatcher.start();
-            super.startQueue();
             return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean startQueue() {
+
+        if (!isInitialized.get()) {
+            // Make it easy for our tests, so they simply call startQueue
+            initQueue();
         }
 
-        if (config.getPersistentQueueMode() == PersistentQueueMode.STICKY_POLLING) {
-            reaper.start();
+        //
+        // The first DefaultNotificationQueue#startQueue will call this method and start the reaper and lifecycle dispatch thread pool
+        // All subsequent DefaultNotificationQueue#startQueue will simply increment the # activeQueues
+        //
+        synchronized (queues) {
+            // Increment number of active queues
+            activeQueues++;
+
+            if (!isStarted) {
+                if (config.getPersistentQueueMode() == PersistentQueueMode.STICKY_POLLING) {
+                    reaper.start();
+                }
+                super.startQueue();
+                isStarted = true;
+                return true;
+            } else {
+                return false;
+            }
         }
-        return false;
+
     }
 
     @Override
     public void stopQueue() {
-        if (!isStarted()) {
-            return;
-        }
-
-        // If there are no active queues left, stop the processing for the queues
-        // (This is not intended to be robust against a system that would stop and start queues at the same time,
-        // for a a normal shutdown sequence)
-        //
-        int nbQueueStarted = 0;
         synchronized (queues) {
-            for (final NotificationQueue cur : queues.values()) {
-                if (cur.isStarted()) {
-                    nbQueueStarted++;
-                }
+            activeQueues--;
+            //
+            // The last DefaultNotificationQueue#stopQueue will call this method and stop the reaper and lifecycle dispatch thread pool
+            //
+            if (activeQueues == 0) {
+                isInitialized.set(false);
+                super.stopQueue();
+                reaper.stop();
+                dispatcher.stop();
+                isStarted = false;
             }
         }
-        if (nbQueueStarted == 0) {
-            dispatcher.stop();
-            super.stopQueue();
-            isStarted.set(false);
-        }
-
-        reaper.stop();
     }
 
     @Override
     public boolean isStarted() {
-        return isStarted.get();
+        return isStarted;
     }
 
     @Override

--- a/queue/src/main/java/org/killbill/queue/api/QueueLifecycle.java
+++ b/queue/src/main/java/org/killbill/queue/api/QueueLifecycle.java
@@ -16,6 +16,9 @@
 package org.killbill.queue.api;
 
 public interface QueueLifecycle {
+
+    boolean initQueue();
+
     /**
      * Starts the queue
      */

--- a/queue/src/test/java/org/killbill/bus/TestInMemoryEventBus.java
+++ b/queue/src/test/java/org/killbill/bus/TestInMemoryEventBus.java
@@ -123,12 +123,12 @@ public class TestInMemoryEventBus {
 
     @BeforeMethod(groups = "fast")
     public void beforeMethod() throws Exception {
-        busService.start();
+        busService.startQueue();
     }
 
     @AfterMethod(groups = "fast")
     public void afterMethod() throws Exception {
-        busService.stop();
+        busService.stopQueue();
     }
 
 

--- a/queue/src/test/java/org/killbill/bus/TestLoadDefaultPersistentBus.java
+++ b/queue/src/test/java/org/killbill/bus/TestLoadDefaultPersistentBus.java
@@ -74,12 +74,12 @@ public class TestLoadDefaultPersistentBus extends TestSetup {
     @BeforeMethod(groups = "load")
     public void beforeMethod() throws Exception {
         super.beforeMethod();
-        eventBus.start();
+        eventBus.startQueue();
     }
 
     @AfterMethod(groups = "load")
     public void afterMethod() throws Exception {
-        eventBus.stop();
+        eventBus.stopQueue();
     }
 
     @Test(groups = "load")

--- a/queue/src/test/java/org/killbill/bus/TestPersistentBusDemo.java
+++ b/queue/src/test/java/org/killbill/bus/TestPersistentBusDemo.java
@@ -82,12 +82,12 @@ public class TestPersistentBusDemo {
     @BeforeMethod(groups = "slow")
     public void beforeMethod() throws Exception {
         embeddedDB.cleanupAllTables();
-        bus.start();
+        bus.startQueue();
     }
 
     @AfterMethod(groups = "slow")
     public void afterMethod() throws Exception {
-        bus.stop();
+        bus.stopQueue();
     }
 
     @Test(groups = "slow")

--- a/queue/src/test/java/org/killbill/bus/TestPersistentEventBus.java
+++ b/queue/src/test/java/org/killbill/bus/TestPersistentEventBus.java
@@ -47,12 +47,12 @@ public class TestPersistentEventBus extends TestSetup {
         // Reinitialize to restart the pool
         busService = new DefaultPersistentBus(getDBI(), clock, getPersistentBusConfig(), metricRegistry, databaseTransactionNotificationApi);
         testEventBusBase = new TestEventBusBase(busService);
-        busService.start();
+        busService.startQueue();
     }
 
     @AfterMethod(groups = "slow")
     public void afterMethod() throws Exception {
-        busService.stop();
+        busService.stopQueue();
     }
 
     @Test(groups = "slow")

--- a/queue/src/test/java/org/killbill/bus/TestRetries.java
+++ b/queue/src/test/java/org/killbill/bus/TestRetries.java
@@ -65,12 +65,12 @@ public class TestRetries extends TestSetup {
         super.beforeMethod();
         queueService = new DefaultNotificationQueueService(getDBI(), clock, getNotificationQueueConfig(), metricRegistry);
         busService = new DefaultPersistentBus(getDBI(), clock, getPersistentBusConfig(), metricRegistry, databaseTransactionNotificationApi);
-        busService.start();
+        busService.startQueue();
     }
 
     @AfterMethod(groups = "slow")
     public void afterMethod() throws Exception {
-        busService.stop();
+        busService.stopQueue();
     }
 
     @Test(groups = "slow")

--- a/queue/src/test/java/org/killbill/notificationq/MockNotificationQueue.java
+++ b/queue/src/test/java/org/killbill/notificationq/MockNotificationQueue.java
@@ -230,6 +230,11 @@ public class MockNotificationQueue implements NotificationQueue {
     }
 
     @Override
+    public boolean initQueue() {
+        return true;
+    }
+
+    @Override
     public boolean startQueue() {
         isStarted = true;
         queueService.startQueue();

--- a/queue/src/test/java/org/killbill/queue/TestReaperIntegration.java
+++ b/queue/src/test/java/org/killbill/queue/TestReaperIntegration.java
@@ -69,7 +69,7 @@ public class TestReaperIntegration extends TestSetup {
 
         config = createConfig();
         bus = new DefaultPersistentBus(dbi, clock, config, metricRegistry, databaseTransactionNotificationApi);
-        bus.start();
+        bus.startQueue();
 
         handler = new DummyHandler();
         bus.register(handler);
@@ -77,7 +77,7 @@ public class TestReaperIntegration extends TestSetup {
 
     @AfterMethod(groups = "slow")
     public void afterMethod() throws Exception {
-        bus.stop();
+        bus.stopQueue();
     }
 
     @Test(groups = "slow")


### PR DESCRIPTION
…er grain lifecyle

The initQueue() starts everything bus the dispatch lifecycle thread pool and the reaper thread.

This way we can start sending events right after initQueue() but no events are being dispatched until the startQueue() is called -- we expect to plug this step as a last step in our lifecyle after
plugins and KB services have been started.

Also:
* Rework the start/stop sequence and make it more homegeneous between NotificationQueue and PersistentBus
* Fix race conditions during stop sequence