### PR TITLE
queue: Remove restriction for when we start reaper (enable for POLLIN…

### DIFF
--- a/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
+++ b/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
@@ -173,9 +173,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
         }
 
         if (isStarted.compareAndSet(false, true)) {
-            if (config.getPersistentQueueMode() == PersistentQueueMode.STICKY_POLLING || config.getPersistentQueueMode() == PersistentQueueMode.STICKY_EVENTS) {
-                reaper.start();
-            }
+            reaper.start();
             super.startQueue();
             return true;
         } else {

--- a/queue/src/main/java/org/killbill/notificationq/NotificationQueueDispatcher.java
+++ b/queue/src/main/java/org/killbill/notificationq/NotificationQueueDispatcher.java
@@ -151,9 +151,7 @@ public class NotificationQueueDispatcher extends DefaultQueueLifecycle {
             activeQueues++;
 
             if (!isStarted) {
-                if (config.getPersistentQueueMode() == PersistentQueueMode.STICKY_POLLING) {
-                    reaper.start();
-                }
+                reaper.start();
                 super.startQueue();
                 isStarted = true;
                 return true;


### PR DESCRIPTION
…G). See #90

The change introduced in https://github.com/killbill/killbill-commons/commit/e5c33a#diff-aea593cacd16e15ced2de4f564c85af592c46636ce1ca8a50633419d1d55d1c3R18 requires the reaper to also redispatch entries that are not `AVAILABLE` to make sure they don't end up staying there for ever. Prior, the `readyWhereClause` logic would have different nodes pick up late entries, but now, we rely on reaper on all modes to do this.