### PR TITLE
queue: revisit shutdown sequence

### DIFF
--- a/queue/src/main/java/org/killbill/bus/InMemoryPersistentBus.java
+++ b/queue/src/main/java/org/killbill/bus/InMemoryPersistentBus.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -145,13 +145,15 @@ public class InMemoryPersistentBus implements PersistentBus {
     }
 
     @Override
-    public void stopQueue() {
+    public boolean stopQueue() {
         if (isInitialized.compareAndSet(true, false)) {
             log.info("InMemoryPersistentBus stopping...");
             delegate.completeDispatch();
             delegate.stop();
             log.info("InMemoryPersistentBus stopped...");
+            return true;
         }
+        return true;
     }
 
     @Override

--- a/queue/src/main/java/org/killbill/bus/api/PersistentBusConfig.java
+++ b/queue/src/main/java/org/killbill/bus/api/PersistentBusConfig.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -134,4 +134,10 @@ public abstract class PersistentBusConfig implements PersistentQueueConfig {
     @Default("3m")
     @Description("Reaper schedule period")
     public abstract TimeSpan getReapSchedule();
+
+    @Override
+    @Config("org.killbill.persistent.bus.${instanceName}.shutdownTimeout")
+    @Default("15s")
+    @Description("Shutdown sequence timeout")
+    public abstract TimeSpan getShutdownTimeout();
 }

--- a/queue/src/main/java/org/killbill/notificationq/DefaultNotificationQueue.java
+++ b/queue/src/main/java/org/killbill/notificationq/DefaultNotificationQueue.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -403,6 +403,7 @@ public class DefaultNotificationQueue implements NotificationQueue {
     @Override
     public boolean initQueue() {
         if (config.isProcessingOff()) {
+            logger.warn("Not initializing queue {} because of xxx.notification.off config", getFullQName());
             return false;
         }
 
@@ -429,12 +430,12 @@ public class DefaultNotificationQueue implements NotificationQueue {
     }
 
     @Override
-    public void stopQueue() {
+    public boolean stopQueue() {
         if (isStarted.compareAndSet(true, false)) {
             isInitialized.set(false);
-            notificationQueueService.stopQueue();
-            return;
+            return notificationQueueService.stopQueue();
         }
+        return true;
     }
 
     @Override

--- a/queue/src/main/java/org/killbill/notificationq/api/NotificationQueueConfig.java
+++ b/queue/src/main/java/org/killbill/notificationq/api/NotificationQueueConfig.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -136,4 +136,10 @@ public abstract class NotificationQueueConfig implements PersistentQueueConfig {
     @Default("3m")
     @Description("Reaper schedule period")
     public abstract TimeSpan getReapSchedule();
+
+    @Override
+    @Config("org.killbill.notificationq.${instanceName}.shutdownTimeout")
+    @Default("15s")
+    @Description("Shutdown sequence timeout")
+    public abstract TimeSpan getShutdownTimeout();
 }

--- a/queue/src/main/java/org/killbill/queue/api/PersistentQueueConfig.java
+++ b/queue/src/main/java/org/killbill/queue/api/PersistentQueueConfig.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -68,4 +68,6 @@ public interface PersistentQueueConfig {
     int getMaxReDispatchCount();
 
     TimeSpan getReapSchedule();
+
+    TimeSpan getShutdownTimeout();
 }

--- a/queue/src/main/java/org/killbill/queue/api/QueueLifecycle.java
+++ b/queue/src/main/java/org/killbill/queue/api/QueueLifecycle.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -16,6 +16,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package org.killbill.queue.api;
 
 public interface QueueLifecycle {
@@ -28,9 +29,9 @@ public interface QueueLifecycle {
     boolean startQueue();
 
     /**
-     * Stop the queue
+     * Stops the queue
      */
-    void stopQueue();
+    boolean stopQueue();
 
     boolean isStarted();
 }

--- a/queue/src/main/java/org/killbill/queue/api/Reaper.java
+++ b/queue/src/main/java/org/killbill/queue/api/Reaper.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -20,15 +20,16 @@
 package org.killbill.queue.api;
 
 public interface Reaper {
+
     /**
      * Starts the reaper
      */
     void start();
 
     /**
-     * Stop the reaper
+     * Stops the reaper
      */
-    void stop();
+    boolean stop();
 
     boolean isStarted();
 }

--- a/queue/src/test/java/org/killbill/bus/TestInMemoryEventBus.java
+++ b/queue/src/test/java/org/killbill/bus/TestInMemoryEventBus.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -117,6 +117,11 @@ public class TestInMemoryEventBus {
             @Override
             public TimeSpan getReapSchedule() {
                 return new TimeSpan(3, TimeUnit.MINUTES);
+            }
+
+            @Override
+            public TimeSpan getShutdownTimeout() {
+                return new TimeSpan(5, TimeUnit.SECONDS);
             }
         });
         testEventBusBase = new TestEventBusBase(busService);

--- a/queue/src/test/java/org/killbill/notificationq/MockNotificationQueue.java
+++ b/queue/src/test/java/org/killbill/notificationq/MockNotificationQueue.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -243,9 +243,9 @@ public class MockNotificationQueue implements NotificationQueue {
     }
 
     @Override
-    public void stopQueue() {
+    public boolean stopQueue() {
         isStarted = false;
-        queueService.stopQueue();
+        return queueService.stopQueue();
     }
 
     @Override

--- a/queue/src/test/java/org/killbill/queue/TestDBBackedQueueWithInflightQ.java
+++ b/queue/src/test/java/org/killbill/queue/TestDBBackedQueueWithInflightQ.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -161,6 +161,11 @@ public class TestDBBackedQueueWithInflightQ extends TestSetup {
             @Override
             public TimeSpan getReapSchedule() {
                 return new TimeSpan(3, TimeUnit.MINUTES);
+            }
+
+            @Override
+            public TimeSpan getShutdownTimeout() {
+                return new TimeSpan(5, TimeUnit.SECONDS);
             }
         };
     }

--- a/queue/src/test/java/org/killbill/queue/TestLoadDBBackedQueue.java
+++ b/queue/src/test/java/org/killbill/queue/TestLoadDBBackedQueue.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -289,6 +289,11 @@ public class TestLoadDBBackedQueue extends TestSetup {
             @Override
             public TimeSpan getReapSchedule() {
                 return new TimeSpan(3, TimeUnit.MINUTES);
+            }
+
+            @Override
+            public TimeSpan getShutdownTimeout() {
+                return new TimeSpan(5, TimeUnit.SECONDS);
             }
         };
     }

--- a/queue/src/test/java/org/killbill/queue/TestReaper.java
+++ b/queue/src/test/java/org/killbill/queue/TestReaper.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -255,6 +255,11 @@ public class TestReaper extends TestSetup {
             @Override
             public TimeSpan getReapSchedule() {
                 return new TimeSpan(3, TimeUnit.MINUTES);
+            }
+
+            @Override
+            public TimeSpan getShutdownTimeout() {
+                return new TimeSpan(5, TimeUnit.SECONDS);
             }
         };
     }

--- a/queue/src/test/java/org/killbill/queue/TestReaperIntegration.java
+++ b/queue/src/test/java/org/killbill/queue/TestReaperIntegration.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -438,6 +438,11 @@ public class TestReaperIntegration extends TestSetup {
             public TimeSpan getReapSchedule() {
                 // Aggressive on purpose
                 return new TimeSpan(1, TimeUnit.SECONDS);
+            }
+
+            @Override
+            public TimeSpan getShutdownTimeout() {
+                return new TimeSpan(5, TimeUnit.SECONDS);
             }
         };
     }

--- a/queue/src/test/java/org/killbill/queue/dispatching/TestDispatcher.java
+++ b/queue/src/test/java/org/killbill/queue/dispatching/TestDispatcher.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -62,8 +62,18 @@ public class TestDispatcher {
         };
 
         this.callback = new TestCallableCallback();
-        this.dispatcher = new Dispatcher<>(1, createConfig(), 5, TimeUnit.MINUTES, new LinkedBlockingQueue<Runnable>(QUEUE_SIZE), testThreadFactory, new TestBlockingRejectionExecutionHandler(callback),
-                                           null, callback, null);
+        this.dispatcher = new Dispatcher<>(1,
+                                           createConfig(),
+                                           5,
+                                           TimeUnit.MINUTES,
+                                           5,
+                                           TimeUnit.SECONDS,
+                                           new LinkedBlockingQueue<Runnable>(QUEUE_SIZE),
+                                           testThreadFactory,
+                                           new TestBlockingRejectionExecutionHandler(callback),
+                                           null,
+                                           callback,
+                                           null);
         this.dispatcher.start();
     }
 
@@ -298,6 +308,11 @@ public class TestDispatcher {
             @Override
             public TimeSpan getReapSchedule() {
                 return new TimeSpan(3, TimeUnit.MINUTES);
+            }
+
+            @Override
+            public TimeSpan getShutdownTimeout() {
+                return new TimeSpan(5, TimeUnit.SECONDS);
             }
         };
     }


### PR DESCRIPTION
Make timeout configurable to wait for executors threads to complete.

Some handlers can take a long time (e.g. Analytics plugin handlers) and the default hardcoded 5s value isn't always enough in practice. This can result in leaving `IN_PROCESSING` entries on disk if the shutdown sequence doesn't wait for these threads to finish.

As part of this, the shutdown sequence was revisited too. With the previous implementation, even if the shutdown sequence waits for these threads to finish, `IN_PROCESSING` entries could still be left on disk if the completion threads are
stopped before all jobs in the dispatcher queue are done.

I've also bumped the default timeout from 5s to 15s (5s might be a bit aggressive, even for core Kill Bill handlers).

It's a ☕ kind of review 😸 Might be easier to checkout the code...