### PR TITLE
Excluded duplicate transitive dependency

### DIFF
--- a/clock/pom.xml
+++ b/clock/pom.xml
@@ -51,6 +51,12 @@
             <groupId>org.redisson</groupId>
             <artifactId>redisson</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.66</version>
+        <version>0.144.73</version>
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>


### PR DESCRIPTION
* Excluded duplicate ByteBuddy dependency from org.redisson group.
* Updated killbill-oss-parent dependency version.