### PR TITLE
.github: add snapshot job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,93 +1,12 @@
 name: ci
 
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
-
-env:
-  MAVEN_FLAGS: "-e -B --no-transfer-progress"
-  MAVEN_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3"
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version:
-          - 11
-          - 16
-        java-distribution:
-          - adopt
-          - zulu
-        profile:
-          - travis
-          - mysql
-          - postgresql
-          - jdbi
-          - config-magic
-    steps:
-      - name: Checkout killbill-commons
-        uses: actions/checkout@v2
-        with:
-          repository: killbill/killbill-commons
-          ref: ${{ github.ref }}
-          path: killbill-commons
-      - name: Setup Java
-        uses: actions/setup-java@v2
-        with:
-          distribution: ${{ matrix.java-distribution }}
-          java-version: ${{ matrix.java-version }}
-      - name: Configure Sonatype mirror
-        uses: s4u/maven-settings-action@v2.3.0
-        # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
-        with:
-          mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "*", "url": "https://oss.sonatype.org/content/repositories/releases/"}]'
-      - name: Check if killbill-oss-parent SNAPSHOT must be fetched
-        id: killbill-oss-parent
-        run: |
-          REMOTE_SHA=$(git ls-remote --heads https://github.com/killbill/killbill-oss-parent.git ${GITHUB_REF##*/})
-          echo "killbill-oss-parent branch=${GITHUB_REF##*/} sha=${REMOTE_SHA}"
-          cd $GITHUB_WORKSPACE/killbill-commons
-          # Cannot use mvn help:evaluate unfortunately, as the project isn't buildable yet
-          PARENT_POM_VERSION=$(
-             awk '
-              /<dependenc/{exit}
-              /<parent>/{parent++};
-              /<version>/{
-                if (parent == 1) {
-                  sub(/.*<version>/, "");
-                  sub(/<.*/, "");
-                  parent_version = $0;
-                }
-              }
-              /<\/parent>/{parent--};
-              END {
-                print parent_version
-              }' pom.xml
-          )
-          echo "killbill-oss-parent version=${PARENT_POM_VERSION}"
-          if [[ "$PARENT_POM_VERSION" =~ .*"-SNAPSHOT".* ]] && [ ! -z "$REMOTE_SHA" ]; then
-            echo "::set-output name=FETCH_SNAPSHOT::true"
-          else
-            echo "::set-output name=FETCH_SNAPSHOT::false"
-          fi
-      - name: Checkout killbill-oss-parent
-        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
-        uses: actions/checkout@v2
-        with:
-          repository: killbill/killbill-oss-parent
-          ref: ${{ github.ref }}
-          path: killbill-oss-parent
-      - name: Build killbill-oss-parent
-        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
-        run: |
-          cd $GITHUB_WORKSPACE/killbill-oss-parent
-          mvn ${MAVEN_FLAGS} clean install -DskipTests=true
-      - name: Tests
-        env:
-          MAVEN_PROFILE: ${{ matrix.profile }}
-        run: |
-          cd $GITHUB_WORKSPACE/killbill-commons
-          mvn ${MAVEN_FLAGS} clean install -P${MAVEN_PROFILE}
+  ci:
+    uses: killbill/gh-actions-shared/.github/workflows/ci.yml@main
+    with:
+      test-profile-matrix: '[ "travis", "mysql", "postgresql", "jdbi", "config-magic" ]'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,12 @@
+name: snapshot
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  snapshot:
+    uses: killbill/gh-actions-shared/.github/workflows/snapshot.yml@main
+    secrets:
+      OSSRH_USER: ${{ secrets.OSSRH_USER }}
+      OSSRH_PASS: ${{ secrets.OSSRH_PASS }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -7,27 +7,6 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: work-for-release-0.23.x
-          ssh-key: ${{ secrets.CREATE_PULL_REQUEST_SSH_KEY }}
-      - name: Setup git user
-        env:
-          BUILD_USER: ${{ secrets.BUILD_USER }}
-          BUILD_TOKEN: ${{ secrets.BUILD_TOKEN }}
-        run: |
-          git config --global user.email "contact@killbill.io"
-          git config --global user.name "Kill Bill core team"
-          git config --global url."https://${BUILD_USER}:${BUILD_TOKEN}@github.com/".insteadOf "git@github.com:"
-      - name: Merge master branch
-        run: |
-          git merge origin/master
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          branch: work-for-release-0.23.x-promotion
-          title: 'Sync master into work-for-release-0.23.x'
-          body: 'Merge latest master into work-for-release-0.23.x'
+    uses: killbill/gh-actions-shared/.github/workflows/sync.yml@main
+    secrets:
+      CREATE_PULL_REQUEST_SSH_KEY: ${{ secrets.CREATE_PULL_REQUEST_SSH_KEY }}


### PR DESCRIPTION
Publish SNAPSHOT builds to Sonatype.

The name will contain the short `sha`. For instance, for this commit, the version is `0.25.1-febe09c-SNAPSHOT`.

This can be found on the job page:
![image](https://user-images.githubusercontent.com/51940/151534272-cba8f815-e6e7-44ca-863e-f61073234d3d.png)

Someone working on a feature should now be able to simply specify in the Kill Bill pom.xml:
```
<killbill-commons.version>0.25.1-febe09c-SNAPSHOT</killbill-commons.version>
```

This also introduces shared jobs from https://github.com/killbill/gh-actions-shared (the CI job has also been migrated as a proof of concept for more complex workflows).