### PR TITLE
queue: ensure the MDC is always cleared after dispatching an entry

### DIFF
--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -66,7 +66,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- Don't run JUnit tests -->
-                    <groups />
+                    <groups/>
                 </configuration>
             </plugin>
         </plugins>

--- a/queue/src/main/java/org/killbill/queue/dispatching/Dispatcher.java
+++ b/queue/src/main/java/org/killbill/queue/dispatching/Dispatcher.java
@@ -186,7 +186,9 @@ public class Dispatcher<E extends QueueEvent, M extends EventEntryModelDao> {
                 }
                 return event;
             } finally {
-                MDC.remove(MDC_KB_USER_TOKEN);
+                // Clear all entries in the MDC: when creating an InternalCallContext while processing an event,
+                // Kill Bill will add entries (e.g. kb.accountRecordId) that we don't want to persist in our queue thread pool.
+                MDC.clear();
             }
         }
     }


### PR DESCRIPTION
Tested manually using breakpoints.