### PR TITLE
embeddeddb: jdbi: support for mariadb-java-client 3.0.4

### DIFF
--- a/embeddeddb/mysql/pom.xml
+++ b/embeddeddb/mysql/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/embeddeddb/mysql/src/main/java/org/killbill/commons/embeddeddb/mysql/MySQLStandaloneDB.java
+++ b/embeddeddb/mysql/src/main/java/org/killbill/commons/embeddeddb/mysql/MySQLStandaloneDB.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -25,7 +25,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.killbill.commons.embeddeddb.GenericStandaloneDB;
-import org.mariadb.jdbc.MariaDbDataSource;
 
 import com.mysql.cj.jdbc.MysqlDataSource;
 
@@ -65,16 +64,14 @@ public class MySQLStandaloneDB extends GenericStandaloneDB {
         super.initialize();
 
         if (useMariaDB) {
-            final MariaDbDataSource mariaDBDataSource = new MariaDbDataSource();
+            final KillBillMariaDbDataSource mariaDBDataSource = new KillBillMariaDbDataSource();
             try {
                 mariaDBDataSource.setUrl(jdbcConnectionString);
             } catch (final SQLException e) {
                 throw new IOException(e);
             }
-            mariaDBDataSource.setDatabaseName(databaseName);
             mariaDBDataSource.setUser(username);
             mariaDBDataSource.setPassword(password);
-            mariaDBDataSource.setPort(port);
             dataSource = mariaDBDataSource;
         } else {
             final MysqlDataSource mysqlDataSource = new MysqlDataSource();

--- a/embeddeddb/mysql/src/test/java/io/airlift/testing/mysql/HackedTestingMySqlServer.java
+++ b/embeddeddb/mysql/src/test/java/io/airlift/testing/mysql/HackedTestingMySqlServer.java
@@ -128,6 +128,6 @@ public class HackedTestingMySqlServer implements Closeable {
 
     // PIERRE: allow multi queries
     public String getJdbcUrl(final String database) {
-        return format("jdbc:mysql://localhost:%s/%s?user=%s&password=%s&useSSL=false&allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true&allowMultiQueries=true", port, database, user, password);
+        return format("jdbc:mysql://localhost:%s/%s?user=%s&password=%s&useSSL=false&allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true&allowMultiQueries=true&permitMysqlScheme=true", port, database, user, password);
     }
 }

--- a/embeddeddb/mysql/src/test/java/org/killbill/commons/embeddeddb/mysql/MySQLEmbeddedDB.java
+++ b/embeddeddb/mysql/src/test/java/org/killbill/commons/embeddeddb/mysql/MySQLEmbeddedDB.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -137,10 +137,8 @@ public class MySQLEmbeddedDB extends EmbeddedDB {
             } catch (final SQLException e) {
                 throw new IOException(e);
             }
-            mariaDBDataSource.setDatabaseName(databaseName);
             mariaDBDataSource.setUser(username);
             mariaDBDataSource.setPassword(password);
-            mariaDBDataSource.setPort(mysqldResource.getPort());
             dataSource = mariaDBDataSource;
         }
     }

--- a/embeddeddb/mysql/src/test/java/org/killbill/commons/embeddeddb/mysql/TestKillBillMariaDbDataSource.java
+++ b/embeddeddb/mysql/src/test/java/org/killbill/commons/embeddeddb/mysql/TestKillBillMariaDbDataSource.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2021 Equinix, Inc
- * Copyright 2014-2021 The Billing Project, LLC
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -29,26 +29,26 @@ public class TestKillBillMariaDbDataSource {
         final KillBillMariaDbDataSource killBillMariaDbDataSource = new KillBillMariaDbDataSource();
 
         Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false"),
-                            "jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true");
+                            "jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true&permitMysqlScheme=true");
         Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill"),
-                            "jdbc:mysql://127.0.0.1:3306/killbill");
+                            "jdbc:mysql://127.0.0.1:3306/killbill?permitMysqlScheme=true");
 
         killBillMariaDbDataSource.setCachePrepStmts(false);
         Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false"),
-                            "jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true");
+                            "jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true&permitMysqlScheme=true");
         Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill"),
-                            "jdbc:mysql://127.0.0.1:3306/killbill?cachePrepStmts=false");
+                            "jdbc:mysql://127.0.0.1:3306/killbill?cachePrepStmts=false&permitMysqlScheme=true");
 
         killBillMariaDbDataSource.setCachePrepStmts(true);
         Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false"),
-                            "jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true");
+                            "jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true&permitMysqlScheme=true");
         Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill"),
-                            "jdbc:mysql://127.0.0.1:3306/killbill?cachePrepStmts=true");
+                            "jdbc:mysql://127.0.0.1:3306/killbill?cachePrepStmts=true&permitMysqlScheme=true");
 
         killBillMariaDbDataSource.setPrepStmtCacheSize(123);
         Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false"),
-                            "jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true&prepStmtCacheSize=123");
+                            "jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true&permitMysqlScheme=true&prepStmtCacheSize=123");
         Assert.assertEquals(killBillMariaDbDataSource.buildUpdatedUrl("jdbc:mysql://127.0.0.1:3306/killbill"),
-                            "jdbc:mysql://127.0.0.1:3306/killbill?cachePrepStmts=true&prepStmtCacheSize=123");
+                            "jdbc:mysql://127.0.0.1:3306/killbill?cachePrepStmts=true&permitMysqlScheme=true&prepStmtCacheSize=123");
     }
 }

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/mapper/LowerToCamelBeanMapper.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/mapper/LowerToCamelBeanMapper.java
@@ -260,7 +260,7 @@ public class LowerToCamelBeanMapper<T> implements ResultSetMapper<T> {
                 // For h2, transform a JdbcBlob into a byte[]
                 if (value instanceof Blob) {
                     final Blob blob = (Blob) value;
-                    value = blob.getBytes(0, (int) blob.length());
+                    value = blob.getBytes(1, (int) blob.length());
                 }
                 if (rs.wasNull() && !type.isPrimitive()) {
                     value = null;

--- a/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
+++ b/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -50,7 +50,7 @@ import org.killbill.commons.embeddeddb.GenericStandaloneDB;
 import org.killbill.commons.embeddeddb.h2.H2EmbeddedDB;
 import org.killbill.commons.embeddeddb.mysql.KillBillMariaDbDataSource;
 import org.killbill.commons.jdbi.guice.DataSourceProvider.DatabaseType;
-import org.mariadb.jdbc.util.Options;
+import org.mariadb.jdbc.Configuration;
 import org.skife.config.ConfigurationObjectFactory;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -186,9 +186,9 @@ public class TestDataSourceProvider {
         assertTrue(wrappedDataSource instanceof KillBillMariaDbDataSource);
 
         final KillBillMariaDbDataSource mariaDbDataSource = (KillBillMariaDbDataSource) wrappedDataSource;
-        final Options options = mariaDbDataSource.initializeAndGetUrlParser().getOptions();
-        assertTrue(options.cachePrepStmts);
-        assertTrue(options.useServerPrepStmts);
+        final Configuration configuration = Configuration.parse(mariaDbDataSource.getUrl());
+        assertTrue(configuration.cachePrepStmts());
+        assertTrue(configuration.useServerPrepStmts());
     }
 
     @Test(groups = "fast")

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-fd02eae-SNAPSHOT</version>
+        <version>0.145.3-9090397-SNAPSHOT</version>
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>


### PR DESCRIPTION
* `permitMysqlScheme` is now required in the jdbc url to support the `jdbc:mysql` scheme.
* The first byte is at position 1 when calling `blob.getBytes` (per the spec). Not sure why we never noticed the issue, I suspect some codepaths aren't exercised.
* Streaming doesn't rely on the `Integer.MIN_VALUE` hint anymore. I've verified streaming still works as expected (a `StreamingResult` is returned of size 1 and fetches data as needed unlike when `CompleteResult` is used, where everything is loaded in memory).