### PR TITLE
queue: address SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA error

### DIFF
--- a/queue/src/main/java/org/killbill/CreatorName.java
+++ b/queue/src/main/java/org/killbill/CreatorName.java
@@ -28,6 +28,8 @@ import com.google.common.base.Strings;
 
 public class CreatorName {
 
+    private static final Object lock = new Object();
+
     // Allow to override the default naming based on Hostname
     static final String QUEUE_CREATOR_NAME = "org.killbill.queue.creator.name";
 
@@ -35,7 +37,7 @@ public class CreatorName {
 
     public static String get() {
         if (creatorName == null) {
-            synchronized (CreatorName.class) {
+            synchronized (lock) {
                 String tmpCreatorName = System.getProperty(QUEUE_CREATOR_NAME);
                 if (Strings.emptyToNull(tmpCreatorName) == null) {
                     try {


### PR DESCRIPTION
This will fail the build when upgrading spotbugs-maven-plugin to 4.6.0.0.