### PR TITLE
junit: update surefire-junit47 to 3.0.0-M6

### DIFF
--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -86,7 +86,7 @@
                             <dependency>
                                 <groupId>org.apache.maven.surefire</groupId>
                                 <artifactId>surefire-junit47</artifactId>
-                                <version>3.0.0-M5</version>
+                                <version>3.0.0-M6</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -238,7 +238,7 @@
                             <dependency>
                                 <groupId>org.apache.maven.surefire</groupId>
                                 <artifactId>surefire-junit47</artifactId>
-                                <version>3.0.0-M5</version>
+                                <version>3.0.0-M6</version>
                             </dependency>
                         </dependencies>
                     </plugin>


### PR DESCRIPTION
Addresses:

```
Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M6:test failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M6:test: java.lang.NoSuchMethodError: 'void org.apache.maven.surefire.api.testset.RunOrderParameters.<init>(java.lang.String, java.io.File, java.lang.Long)'
```