### PR TITLE
WIP - Metrics interfaces Proposal

### DIFF
--- a/metrics-api/src/main/java/org/killbill/commons/metrics/api/Counter.java
+++ b/metrics-api/src/main/java/org/killbill/commons/metrics/api/Counter.java
@@ -20,21 +20,21 @@ package org.killbill.commons.metrics.api;
 /**
  * An incrementing and decrementing counter metric.
  */
-public interface Counter extends Metric, Counting {
+public interface Counter extends Metric {
 
     /**
      * Increment the counter by {@code n}.
      *
      * @param n the amount by which the counter will be increased
      */
-    void inc(long n);
+    void inc(double n, String ...labels);
 
     /**
-     * Decrement the counter by {@code n}.
-     *
-     * @param n the amount by which the counter will be decreased
+     * Increment the counter by 1.
      */
-    default void dec(final long n) {
-        inc(-n);
+    default void inc(String ...labels) {
+        inc(1, labels);
     }
+
+    double get(String... labels);
 }

--- a/metrics-api/src/main/java/org/killbill/commons/metrics/api/Histogram.java
+++ b/metrics-api/src/main/java/org/killbill/commons/metrics/api/Histogram.java
@@ -18,14 +18,14 @@
 package org.killbill.commons.metrics.api;
 
 /**
- * A metric which calculates the distribution of a value.
+ * A metric which calculates the distribution of a value into specific value buckets.
  */
-public interface Histogram extends Metric, Sampling, Counting {
+public interface Histogram extends Metric {
 
     /**
      * Adds a recorded value.
      *
      * @param value the length of the value
      */
-    void update(long value);
+    void update(double value, String ...labels);
 }

--- a/metrics-api/src/main/java/org/killbill/commons/metrics/api/MetricRegistry.java
+++ b/metrics-api/src/main/java/org/killbill/commons/metrics/api/MetricRegistry.java
@@ -17,7 +17,7 @@
 
 package org.killbill.commons.metrics.api;
 
-import java.util.Map;
+import java.util.function.DoubleSupplier;
 
 public interface MetricRegistry {
 
@@ -28,7 +28,7 @@ public interface MetricRegistry {
      * @param name the name of the metric
      * @return a new or pre-existing {@link Counter}
      */
-    public Counter counter(String name);
+    Counter counter(String name, String ...labelNames);
 
     /**
      * Return the {@link Gauge} registered under this name; or create and register
@@ -38,34 +38,25 @@ public interface MetricRegistry {
      * @param supplier the underlying Gauge
      * @return a new or pre-existing {@link Gauge}
      */
-    <T> Gauge<T> gauge(String name, Gauge<T> supplier);
+    Gauge gauge(String name, String ...labelNames);
+
+    Gauge gauge(String name, DoubleSupplier supplier, String ...labelNames);
 
     /**
      * Return the {@link Histogram} registered under this name; or create and register
-     * a new {@link Histogram} if none is registered.
+     * a new {@link Histogram} if none is registered using the implementation's default
+     * bucket distribution.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Histogram}
      */
-    Histogram histogram(String name);
+    Histogram histogram(String name, String ...labelNames);
 
-    /**
-     * Return the {@link Meter} registered under this name; or create and register
-     * a new {@link Meter} if none is registered.
-     *
-     * @param name the name of the metric
-     * @return a new or pre-existing {@link Meter}
-     */
-    public Meter meter(String name);
+    Histogram histogram(String name, double[] buckets, String ...labelNames);
 
-    /**
-     * Return the {@link Timer} registered under this name; or create and register
-     * a new {@link Timer} if none is registered.
-     *
-     * @param name the name of the metric
-     * @return a new or pre-existing {@link Timer}
-     */
-    Timer timer(String name);
+    Summary summary(String name, String ...labelNames);
+
+    Summary summary(String name, double[] quantiles, String ...labelNames);
 
     /**
      * Removes the metric with the given name.
@@ -73,17 +64,5 @@ public interface MetricRegistry {
      * @param name the name of the metric
      * @return whether or not the metric was removed
      */
-    boolean remove(String name);
-
-    Map<String, ?> getMetrics();
-
-    Map<String, Counter> getCounters();
-
-    Map<String, Histogram> getHistograms();
-
-    Map<String, Gauge<?>> getGauges();
-
-    Map<String, Meter> getMeters();
-
-    Map<String, Timer> getTimers();
+    boolean remove(String name, String ...labelNames);
 }

--- a/metrics-api/src/main/java/org/killbill/commons/metrics/api/Summary.java
+++ b/metrics-api/src/main/java/org/killbill/commons/metrics/api/Summary.java
@@ -17,21 +17,10 @@
 
 package org.killbill.commons.metrics.api;
 
-public interface Gauge extends Metric {
+/**
+ * A metric which calculates the distribution of a value into quantiles.
+ */
+public interface Summary extends Metric {
 
-    void set(double value, String ...labels);
-
-    void inc(double value, String... labels);
-
-    default void inc(String ...labels) {
-        inc(1, labels);
-    }
-
-    void dec(double value, String... labels);
-
-    default void dec(String ...labels) {
-        dec(1, labels);
-    }
-
-    double get(String ...labels);
+    void update(double value, String ...labels);
 }


### PR DESCRIPTION
### Summary of Proposal
* Removes `Timer` and `Meter` metrics (can be replaced by `Histogram`/`Summary` and `Counter`, respectively)
* Use `double` for metric values,  still compatible enough with `long`, but more flexible in terms of values that can be stored
* Make `Gauge` interface simpler to use, providing `set`, `inc` and `dec` methods, and using a `Supplier` to create the metric.
* Defines the `Summary` metric, which is a metric that's suited for quantile computation on client side (equivalent to Dropwizard's Histogram)
* Changes `Histogram` definition, using metric value range buckets, which is better suited for aggregation
### Labels
* Allows passing labels when creating the metrics, and when providing samples
* For now all labels keys and values are `String` instances.
* Label values would be matched to their keys by the order that their provided (a bit fragile)
* We could evaluate creating a `Label` class for encapsulation (we do that in our golang library)
  * Benefit of making it easier to introduce changes to labels without changing method signatures