### PR TITLE
1615 killbill utils cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Kill Bill reusable Java components:
 * **metrics**: annotation-based metrics
 * **queue**: provides persistent bus events and notifications
 * **skeleton**: framework to build web services
-* **utils**: provides utility methods for core Java(tm) classes (lang, IO, collection)
+* **utils**: provides utility methods for core Java(tm) classes (lang, IO, collection) and Cache
 * **xmlloader**: library to load, parse and validate XML files
 
 ## Kill Bill compatibility

--- a/queue/src/test/java/org/killbill/bus/TestInMemoryEventBus.java
+++ b/queue/src/test/java/org/killbill/bus/TestInMemoryEventBus.java
@@ -35,7 +35,7 @@ public class TestInMemoryEventBus {
     private TestEventBusBase testEventBusBase;
     private PersistentBus busService;
 
-    @BeforeClass(groups = "fast", alwaysRun = true)
+    @BeforeClass(groups = "fast")
     public void beforeClass() throws Exception {
         busService = new InMemoryPersistentBus(new PersistentBusConfig() {
             @Override

--- a/queue/src/test/java/org/killbill/bus/TestInMemoryEventBus.java
+++ b/queue/src/test/java/org/killbill/bus/TestInMemoryEventBus.java
@@ -35,7 +35,7 @@ public class TestInMemoryEventBus {
     private TestEventBusBase testEventBusBase;
     private PersistentBus busService;
 
-    @BeforeClass(groups = "fast")
+    @BeforeClass(groups = "fast", alwaysRun = true)
     public void beforeClass() throws Exception {
         busService = new InMemoryPersistentBus(new PersistentBusConfig() {
             @Override
@@ -133,7 +133,7 @@ public class TestInMemoryEventBus {
     }
 
     @AfterMethod(groups = "fast")
-    public void afterMethod() throws Exception {
+    public void afterMethod() {
         busService.stopQueue();
     }
 
@@ -148,12 +148,12 @@ public class TestInMemoryEventBus {
         testEventBusBase.testDifferentType();
     }
 
-    @Test(groups = "slow")
+    @Test(groups = "fast")
     public void testSimpleWithExceptionAndRetrySuccess() {
         testEventBusBase.testSimpleWithExceptionAndRetrySuccess();
     }
 
-    @Test(groups = "slow")
+    @Test(groups = "fast")
     public void testSimpleWithExceptionAndFail() {
         testEventBusBase.testSimpleWithExceptionAndFail();
     }

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -41,13 +41,13 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/utils/src/main/java/org/killbill/commons/utils/annotation/VisibleForTesting.java
+++ b/utils/src/main/java/org/killbill/commons/utils/annotation/VisibleForTesting.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.utils.annotation;
+
+public @interface VisibleForTesting {
+}

--- a/utils/src/main/java/org/killbill/commons/utils/cache/Cache.java
+++ b/utils/src/main/java/org/killbill/commons/utils/cache/Cache.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.utils.cache;
+
+import java.util.function.Function;
+
+public interface Cache <K, V> {
+
+    /**
+     * Get the cache value, or null if no value associated with key. Value returned by this method depends on
+     * implementation logic.
+     *
+     * @param key to load the value
+     * @return cache value, or null
+     */
+    V get(K key);
+
+    /**
+     * Get or load the cache. Note that value returned from loader parameter will not update cache.
+     *
+     * Implementation may decide to load it first from any other source/loader before loader paramter called.
+     *
+     * @param key to load the value
+     * @param loader algorithm to load a value if, not exist in cache
+     * @return cache value, or depends on {@code loader} algorithm
+     */
+    V getOrLoad(K key, Function<K, V> loader);
+
+    /**
+     * Add value to cache.
+     * @param key key
+     * @param value value
+     */
+    void put(K key, V value);
+
+    /**
+     * Remove the cache based on its key.
+     * @param key to remove.
+     */
+    void invalidate(K key);
+}

--- a/utils/src/main/java/org/killbill/commons/utils/cache/Cache.java
+++ b/utils/src/main/java/org/killbill/commons/utils/cache/Cache.java
@@ -27,17 +27,19 @@ public interface Cache <K, V> {
      *
      * @param key to load the value
      * @return cache value, or null
+     * @throws NullPointerException is key is null
      */
     V get(K key);
 
     /**
      * Get or load the cache. Note that value returned from loader parameter will not update cache.
      *
-     * Implementation may decide to load it first from any other source/loader before loader paramter called.
+     * Implementation may decide to load it first from any other source/loader before loader parameter called.
      *
      * @param key to load the value
      * @param loader algorithm to load a value if, not exist in cache
      * @return cache value, or depends on {@code loader} algorithm
+     * @throws NullPointerException if key or loader is null
      */
     V getOrLoad(K key, Function<K, V> loader);
 
@@ -45,12 +47,14 @@ public interface Cache <K, V> {
      * Add value to cache.
      * @param key key
      * @param value value
+     * @throws NullPointerException if key or value is null
      */
     void put(K key, V value);
 
     /**
      * Remove the cache based on its key.
      * @param key to remove.
+     * @throws NullPointerException if key is null
      */
     void invalidate(K key);
 }

--- a/utils/src/main/java/org/killbill/commons/utils/cache/DefaultCache.java
+++ b/utils/src/main/java/org/killbill/commons/utils/cache/DefaultCache.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.utils.cache;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+
+import org.killbill.commons.utils.annotation.VisibleForTesting;
+
+/**
+ * <p>
+ *     Default {@link Cache} implementation, that provide ability to:
+ *     <ol>
+ *         <li>Add maxSize to the cache. If more entry added, the oldest entry get removed automatically</li>
+ *         <li>
+ *             Add lazy-loading capability with {@code cacheLoader} parameter in constructor. This {@code cacheLoader}
+ *             will be called if {@link #get(Object)} return {@code null}. {@code cacheLoader} also will take precedence
+ *             over loader defined in {@link #getOrLoad(Object, Function)}.
+ *         </li>
+ *         <li>Add timout (similar to expire-after-write in Guava and Caffeine) capability</li>
+ *     </ol>
+ * </p>
+ * @param <K> cache key
+ * @param <V> cache value
+ */
+public class DefaultCache<K, V> implements Cache<K, V> {
+
+    public static final long NO_TIMEOUT = 0;
+
+    @VisibleForTesting
+    final Map<K, TimedValue<V>> map;
+
+    private final long timeoutMillis;
+    private final Function<K, V> cacheLoader;
+
+    /**
+     * Create cache with maximum entry size, without any timout (live forever) and no cache loader.
+     *
+     * @param maxSize max entry that should be existed in cache.
+     */
+    public DefaultCache(final int maxSize) {
+        this(maxSize, NO_TIMEOUT, noCacheLoader());
+    }
+
+    /**
+     * Create cache with maximum entry size, timeout (in second), and cacheLoader capability.
+     *
+     * @param maxSize cache maximum size. If more entry added, the oldest entry get removed automatically.
+     * @param timeoutInSecond cache entry expire time. Entry will eventually be removed after specifics time defined
+     *                        here. Use {@link DefaultCache#NO_TIMEOUT} to make entry live forever.
+     * @param cacheLoader cache loader. Use {@link #noCacheLoader()} to make this cache should not attempt to load
+     *                    anything if value is null.
+     */
+    public DefaultCache(final int maxSize, final long timeoutInSecond, final Function<K, V> cacheLoader) {
+        this.timeoutMillis = timeoutInSecond * 1_000;
+        this.cacheLoader = cacheLoader;
+
+        map = new LinkedHashMap<>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(final Entry<K, TimedValue<V>> eldest) {
+                return size() > maxSize;
+            }
+        };
+    }
+
+    /**
+     * Create {@link DefaultCache} without any loader.
+     */
+    public static <K1, V1> Function<K1, V1> noCacheLoader() {
+        return k1 -> null;
+    }
+
+    protected boolean isTimeoutEnabled() {
+        return timeoutMillis > 0L;
+    }
+
+    protected boolean isCacheLoaderExist() {
+        return !noCacheLoader().equals(cacheLoader);
+    }
+
+    protected void evictExpireEntry(final K key) {
+        if (isTimeoutEnabled()) {
+            final TimedValue<V> value = map.get(key);
+            if (value != null && value.isTimeout()) {
+                invalidate(key);
+            }
+        }
+    }
+
+    @Override
+    public V get(final K key) {
+        evictExpireEntry(key);
+
+        final TimedValue<V> timedValue = map.get(key);
+        if (timedValue != null) {
+            return timedValue.getValue();
+        } else if (isCacheLoaderExist()) {
+            final V value = cacheLoader.apply(key);
+            if (value != null) {
+                put(key, value);
+            }
+            return value;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public V getOrLoad(final K key, final Function<K, V> loader) {
+        final V value = get(key);
+        return value == null ? loader.apply(key) : value;
+    }
+
+    @Override
+    public void put(final K key, final V value) {
+        evictExpireEntry(key);
+
+        map.put(key, new TimedValue<>(timeoutMillis, value));
+    }
+
+    @Override
+    public void invalidate(final K key) {
+        map.remove(key);
+    }
+}

--- a/utils/src/main/java/org/killbill/commons/utils/cache/DefaultSynchronizedCache.java
+++ b/utils/src/main/java/org/killbill/commons/utils/cache/DefaultSynchronizedCache.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.utils.cache;
+
+import java.util.function.Function;
+
+/**
+ * {@link DefaultCache} that synchronize {@link Cache} methods call.
+ */
+public class DefaultSynchronizedCache<K, V> extends DefaultCache<K, V> implements Cache<K, V> {
+
+    public DefaultSynchronizedCache(final int maxSize, final long timeoutInSecond, final Function<K, V> cacheLoader) {
+        super(maxSize, timeoutInSecond, cacheLoader);
+    }
+
+    public DefaultSynchronizedCache(final int maxSize) {
+        super(maxSize);
+    }
+
+    @Override
+    public V get(final K key) {
+        synchronized (this) {
+            return super.get(key);
+        }
+    }
+
+    @Override
+    public V getOrLoad(final K key, final Function<K, V> loader) {
+        synchronized (this) {
+            return super.getOrLoad(key, loader);
+        }
+    }
+
+    @Override
+    public void put(final K key, final V value) {
+        synchronized (this) {
+            super.put(key, value);
+        }
+    }
+
+    @Override
+    public void invalidate(final K key) {
+        synchronized (this) {
+            super.invalidate(key);
+        }
+    }
+}

--- a/utils/src/main/java/org/killbill/commons/utils/cache/TimedValue.java
+++ b/utils/src/main/java/org/killbill/commons/utils/cache/TimedValue.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.utils.cache;
+
+import java.util.Objects;
+
+class TimedValue<V> {
+
+    private final long expireTime;
+    private final V value;
+
+    /**
+     * @param timeoutMillis timeout in millisecond
+     */
+    TimedValue(final long timeoutMillis, final V value) {
+        this.expireTime = System.currentTimeMillis() + timeoutMillis;
+        this.value = value;
+    }
+
+    boolean isTimeout() {
+        return System.currentTimeMillis() >= expireTime;
+    }
+
+    V getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "TimedValue {" +
+               "expireTime=" + expireTime +
+               ", value=" + value +
+               '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TimedValue<?> that = (TimedValue<?>) o;
+        return expireTime == that.expireTime && value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expireTime, value);
+    }
+}

--- a/utils/src/main/java/org/killbill/commons/utils/cache/TimedValue.java
+++ b/utils/src/main/java/org/killbill/commons/utils/cache/TimedValue.java
@@ -19,6 +19,8 @@ package org.killbill.commons.utils.cache;
 
 import java.util.Objects;
 
+import org.killbill.commons.utils.Preconditions;
+
 class TimedValue<V> {
 
     private final long expireTime;
@@ -29,7 +31,7 @@ class TimedValue<V> {
      */
     TimedValue(final long timeoutMillis, final V value) {
         this.expireTime = System.currentTimeMillis() + timeoutMillis;
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "TimedValue.value cannot be null");
     }
 
     boolean isTimeout() {

--- a/utils/src/test/java/org/killbill/commons/utils/cache/TestDefaultCache.java
+++ b/utils/src/test/java/org/killbill/commons/utils/cache/TestDefaultCache.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.utils.cache;
+
+import java.util.function.Function;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestDefaultCache {
+
+    private static final int DEFAULT_MAX_SIZE = 3;
+
+    private DefaultCache<Integer, String> createDefaultCache() {
+        return new DefaultCache<>(DEFAULT_MAX_SIZE);
+    }
+
+    private DefaultCache<Integer, String> createDefaultCacheWithLoader(final Function<Integer, String> cacheLoader) {
+        return new DefaultCache<>(DEFAULT_MAX_SIZE, DefaultCache.NO_TIMEOUT, cacheLoader);
+    }
+
+    private DefaultCache<Integer, String> createDefaultCacheWithTimeout(final int timeout) {
+        return new DefaultCache<>(DEFAULT_MAX_SIZE, timeout, DefaultCache.noCacheLoader());
+    }
+
+    @Test(groups = "fast")
+    public void testPut() {
+        final DefaultCache<Integer, String> cache = createDefaultCache();
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+        cache.put(3, "C");
+        cache.put(4, "D");
+
+        Assert.assertNull(cache.map.get(1)); // null, because maxSize = 3
+        Assert.assertNotNull(cache.map.get(2));
+        Assert.assertNotNull(cache.map.get(3));
+        Assert.assertNotNull(cache.map.get(4));
+    }
+
+    @Test(groups = "fast")
+    public void testPutWithCacheLoader() {
+        // Cache loader algorithm should not affected #put() operation.
+        final DefaultCache<Integer, String> cache = createDefaultCacheWithLoader(key -> {
+            if (key == 5) {
+                return "E";
+            }
+            return null;
+        });
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+        cache.put(3, "C");
+        cache.put(4, "D");
+
+        Assert.assertNull(cache.map.get(1));
+        Assert.assertNotNull(cache.map.get(2));
+        Assert.assertNotNull(cache.map.get(3));
+        Assert.assertNotNull(cache.map.get(4));
+
+        Assert.assertNull(cache.map.get(5)); // cache loader not playing a role here
+    }
+
+    @Test(groups = "fast")
+    public void testPutWithTimeout() throws InterruptedException {
+        final DefaultCache<Integer, String> cache = createDefaultCacheWithTimeout(2); // 2 sec
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+        cache.put(3, "C");
+        cache.put(4, "D");
+
+        Assert.assertNull(cache.map.get(1));
+        Assert.assertNotNull(cache.map.get(2));
+        Assert.assertNotNull(cache.map.get(3));
+        Assert.assertNotNull(cache.map.get(4));
+
+        Thread.sleep(2100);
+
+        // call put here to trigger eviction
+        cache.put(5, "E");
+        Assert.assertNotNull(cache.map.get(5));
+
+        cache.get(2); // Needed to trigger eviction
+        cache.get(3); // Needed to trigger eviction
+        cache.get(4); // Needed to trigger eviction
+
+        Assert.assertNull(cache.map.get(2));
+        Assert.assertNull(cache.map.get(3));
+        Assert.assertNull(cache.map.get(4));
+    }
+
+    @Test(groups = "fast")
+    public void testGet() {
+        final DefaultCache<Integer, String> cache = createDefaultCache();
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+        cache.put(3, "C");
+        cache.put(4, "D");
+
+        Assert.assertNull(cache.get(1)); // removed because eldest entry
+        Assert.assertNotNull(cache.get(2));
+        Assert.assertNotNull(cache.get(3));
+        Assert.assertNotNull(cache.get(4));
+    }
+
+    @Test(groups = "fast")
+    public void testGetWithLoader() {
+        final DefaultCache<Integer, String> cache = createDefaultCacheWithLoader(key -> {
+            switch (key) {
+                case 5: return "E";
+                case 6: return "F";
+            }
+            return null;
+        });
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+
+        Assert.assertNotNull(cache.get(1));
+        Assert.assertNotNull(cache.get(2));
+
+        Assert.assertEquals(cache.map.size(), 2); // map size not affected by loader, yet
+
+        Assert.assertNotNull(cache.get(5));
+        Assert.assertNotNull(cache.get(6));
+
+        Assert.assertEquals(cache.map.size(), 3); // map size affected by loader, but "3" (instead of 4) because maxSize = 3.
+    }
+
+    @Test(groups = "fast")
+    public void testGetWithTimeout() throws InterruptedException {
+        final DefaultCache<Integer, String> cache = createDefaultCacheWithTimeout(1);
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+
+        Assert.assertNotNull(cache.get(1));
+        Assert.assertNotNull(cache.get(2));
+        Assert.assertNull(cache.get(3));
+
+        Thread.sleep(1010);
+
+        // 2, because although expired, there's no operation that removed entry, performed
+        Assert.assertEquals(cache.map.size(), 2);
+
+        // Calling get will remove entry
+        Assert.assertNull(cache.get(1)); // null because expired
+        Assert.assertNull(cache.get(2)); // null because expired
+        Assert.assertNull(cache.get(3));
+
+        Assert.assertEquals(cache.map.size(), 0); // All expired
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+        Assert.assertEquals(cache.map.size(), 2);
+
+        Thread.sleep(1010);
+
+        cache.put(1, "A");
+        cache.get(2); // Needed to trigger eviction
+        Assert.assertEquals(cache.map.size(), 1); // Because expired
+    }
+
+    @Test(groups = "fast")
+    public void testGetOrLoad() {
+        final DefaultCache<Integer, String> cache = createDefaultCache();
+        final Function<Integer, String> loader = key -> key + "00";
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+
+        Assert.assertEquals(cache.getOrLoad(1, loader), "A");
+        Assert.assertEquals(cache.getOrLoad(2, loader), "B");
+        Assert.assertEquals(cache.getOrLoad(3, loader), "300");
+
+        Assert.assertNotNull(cache.getOrLoad(1, key -> null));
+        Assert.assertNotNull(cache.getOrLoad(2, key -> null));
+    }
+
+    @Test(groups = "fast")
+    public void testGetOrLoadWithLoader() {
+        final DefaultCache<Integer, String> cache = createDefaultCacheWithLoader(key -> {
+            switch (key) {
+                case 3: return "C";
+                case 4: return "D";
+            }
+            return null;
+        });
+        final Function<Integer, String> localLoader = key -> {
+            switch (key) {
+                case 5: return "E";
+                case 6: return "F";
+                /*
+                 * Should never showing up, as per {@link DefaultCache} javadoc: ".... cacheLoader also will take
+                 * precedence over loader defined in getOrLoad(Object, Function)."
+                 */
+                case 4: return "D-override";
+            }
+            return null;
+        };
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+
+        Assert.assertEquals(cache.getOrLoad(1, localLoader), "A");
+        Assert.assertEquals(cache.getOrLoad(2, localLoader), "B");
+
+        Assert.assertEquals(cache.map.size(), 2); // 2, because DefaultCache loader "load lazily"
+
+        Assert.assertEquals(cache.getOrLoad(3, localLoader), "C");
+        Assert.assertEquals(cache.getOrLoad(4, localLoader), "D");
+
+        // 3, because DefaultCache loader loaded, but when key '4' added, cache reach max size ....
+        Assert.assertEquals(cache.map.size(), 3);
+
+        // .... and thus 1 get removed
+        Assert.assertNull(cache.getOrLoad(1, localLoader));
+
+        Assert.assertEquals(cache.getOrLoad(5, localLoader), "E");
+        Assert.assertEquals(cache.getOrLoad(6, localLoader), "F");
+
+        Assert.assertEquals(cache.map.size(), 3); // still 3 because localLoader not affected cache.
+
+        Assert.assertNull(cache.getOrLoad(7, localLoader)); // null because 7 not defined everywhere
+    }
+
+    @Test(groups = "fast")
+    public void testGetOrLoadWithTimeout() throws InterruptedException {
+        final DefaultCache<Integer, String> cache = createDefaultCacheWithTimeout(1);
+
+        final Function<Integer, String> localLoader = key -> {
+            switch (key) {
+                case 3: return "C";
+                case 4: return "D";
+            }
+            return null;
+        };
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+
+        Assert.assertEquals(cache.getOrLoad(1, localLoader), "A");
+        Assert.assertEquals(cache.getOrLoad(2, localLoader), "B");
+        Assert.assertEquals(cache.getOrLoad(3, localLoader), "C");
+
+        Thread.sleep(1010);
+
+        // 2, because although timeout, there's no operation that removed entry, performed
+        // Also 2, because "localLoader" not added to cache
+        Assert.assertEquals(cache.map.size(), 2);
+
+        // Calling get will remove entry
+        Assert.assertNull(cache.getOrLoad(1, localLoader)); // null because expired
+        Assert.assertNull(cache.getOrLoad(2, localLoader)); // null because expired
+        Assert.assertEquals(cache.getOrLoad(3, localLoader), "C");
+        Assert.assertEquals(cache.getOrLoad(4, localLoader), "D");
+
+        Assert.assertEquals(cache.map.size(), 0); // All expired
+
+        cache.put(1, "A");
+        cache.put(2, "B");
+        Assert.assertEquals(cache.map.size(), 2);
+
+        Thread.sleep(1010);
+
+        cache.put(1, "A");
+        cache.get(2); // Needed to trigger eviction
+        Assert.assertEquals(cache.map.size(), 1); // Because expired
+    }
+}


### PR DESCRIPTION
Add cache implementation.

Note for `TestInMemoryEventBus` :

- Test methods mixed with "slow" and "fast" test group. Decided to make it "fast" because it supposed to be "fast" tests
- add `alwaysRun = true` because sometimes test failed with NPE (for example NPE in line 153, or 158)