### PR TITLE
1615 remove guava part 4

### DIFF
--- a/automaton/pom.xml
+++ b/automaton/pom.xml
@@ -40,10 +40,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
@@ -61,6 +57,10 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>

--- a/automaton/src/main/java/org/killbill/automaton/DefaultStateMachine.java
+++ b/automaton/src/main/java/org/killbill/automaton/DefaultStateMachine.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -34,9 +36,6 @@ import javax.xml.bind.annotation.XmlID;
 
 import org.killbill.xmlloader.ValidationErrors;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
@@ -126,12 +125,10 @@ public class DefaultStateMachine extends StateMachineValidatingConfig<DefaultSta
     }
 
     public boolean hasTransitionsFromStates(final String initState) {
-        return Iterables.filter(ImmutableList.copyOf(transitions), new Predicate<Transition>() {
-            @Override
-            public boolean apply(final Transition input) {
-                return input != null && input.getInitialState().getName().equals(initState);
-            }
-        }).iterator().hasNext();
+        return Stream.of(transitions)
+                     .filter(input -> input != null && input.getInitialState().getName().equals(initState))
+                     .iterator()
+                     .hasNext();
     }
 
     public void setStates(final DefaultState[] states) {
@@ -157,16 +154,14 @@ public class DefaultStateMachine extends StateMachineValidatingConfig<DefaultSta
     public DefaultTransition findTransition(final State initialState, final Operation operation, final OperationResult operationResult)
             throws MissingEntryException {
         try {
-            return Iterables.tryFind(ImmutableList.<DefaultTransition>copyOf(transitions), new Predicate<DefaultTransition>() {
-                @Override
-                public boolean apply(final DefaultTransition input) {
-                    return input != null &&
-                           input.getInitialState().getName().equals(initialState.getName()) &&
-                           input.getOperation().getName().equals(operation.getName()) &&
-                           input.getOperationResult().equals(operationResult);
-                }
-            }).get();
-        } catch (final IllegalStateException e) {
+            return Stream.of(transitions)
+                         .filter(input -> input != null &&
+                                          input.getInitialState().getName().equals(initialState.getName()) &&
+                                          input.getOperation().getName().equals(operation.getName()) &&
+                                          input.getOperationResult().equals(operationResult))
+                         .findFirst()
+                         .get();
+        } catch (final NoSuchElementException e) {
             throw new MissingEntryException("Missing transition for initialState " + initialState.getName() +
                                             ", operation = " + operation.getName() + ", result = " + operationResult, e);
         }

--- a/automaton/src/main/java/org/killbill/automaton/dot/DOTBuilder.java
+++ b/automaton/src/main/java/org/killbill/automaton/dot/DOTBuilder.java
@@ -22,16 +22,17 @@ package org.killbill.automaton.dot;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.common.base.Joiner;
 import javax.annotation.Nullable;
+
+import org.killbill.commons.utils.MapJoiner;
 
 public class DOTBuilder {
 
     private static final String INDENT = "    ";
     private static final String NEW_LINE = "\n";
     private static final String SPACE = " ";
-    private static final Joiner SPACE_JOINER = Joiner.on(SPACE);
     private static final String EQUAL = "=";
+    private static final MapJoiner MAP_JOINER = new MapJoiner(EQUAL, SPACE);
     private static final String SEMI_COLON = ";";
 
     private final String name;
@@ -56,7 +57,7 @@ public class DOTBuilder {
 
     public int addNode(final String name, @Nullable final Map<String, String> attributesOrNull) {
         // attributes is for example label="Foo" or shape=box
-        final Map<String, String> attributes = new HashMap<String, String>();
+        final Map<String, String> attributes = new HashMap<>();
         attributes.put("label", name);
         if (attributesOrNull != null) {
             attributes.putAll(attributesOrNull);
@@ -172,7 +173,7 @@ public class DOTBuilder {
 
     private void addAttributesInline(@Nullable final Map<String, String> attributes, final boolean withSpace, final boolean withBrackets) {
         if (attributes != null) {
-            final String attributesSymbol = (withSpace ? SPACE : "") + (withBrackets ? "[" : "") + SPACE_JOINER.withKeyValueSeparator(EQUAL).join(attributes) + (withBrackets ? "]" : "");
+            final String attributesSymbol = (withSpace ? SPACE : "") + (withBrackets ? "[" : "") + MAP_JOINER.join(attributes) + (withBrackets ? "]" : "");
             output.append(attributesSymbol);
         }
         output.append(SEMI_COLON)

--- a/automaton/src/main/java/org/killbill/automaton/dot/DefaultStateMachineConfigDOTGenerator.java
+++ b/automaton/src/main/java/org/killbill/automaton/dot/DefaultStateMachineConfigDOTGenerator.java
@@ -24,8 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-
-import com.google.common.collect.ImmutableMap;
 import org.killbill.automaton.*;
 import org.killbill.automaton.graph.Helpers;
 
@@ -115,12 +113,12 @@ public class DefaultStateMachineConfigDOTGenerator {
         }
 
         final String label = String.format("<%s<SUB>|%s</SUB>>", transition.getOperation().getName(), transition.getOperationResult().name().charAt(0));
-        dot.addPath(fromNodeId, toNodeId, ImmutableMap.<String, String>of("label", label, "color", color));
+        dot.addPath(fromNodeId, toNodeId, Map.<String, String>of("label", label, "color", color));
     }
 
     private void drawLinkStateMachine(final LinkStateMachine linkStateMachine) {
         final Integer fromNodeId = statesNodeIds.get(linkStateMachine.getInitialState().getName());
         final Integer toNodeId = statesNodeIds.get(linkStateMachine.getFinalState().getName());
-        dot.addPath(fromNodeId, toNodeId, ImmutableMap.<String, String>of("style", "dotted"));
+        dot.addPath(fromNodeId, toNodeId, Map.<String, String>of("style", "dotted"));
     }
 }

--- a/automaton/src/test/java/org/killbill/automaton/TestStateMachine.java
+++ b/automaton/src/test/java/org/killbill/automaton/TestStateMachine.java
@@ -20,13 +20,12 @@
 
 package org.killbill.automaton;
 
+import org.killbill.commons.utils.io.Resources;
 import org.killbill.xmlloader.XMLLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.io.Resources;
 
 public class TestStateMachine {
 

--- a/automaton/src/test/java/org/killbill/automaton/dot/TestDOTBuilder.java
+++ b/automaton/src/test/java/org/killbill/automaton/dot/TestDOTBuilder.java
@@ -20,95 +20,96 @@
 
 package org.killbill.automaton.dot;
 
+import java.util.Map;
+import java.util.TreeMap;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 public class TestDOTBuilder {
 
-    @Test(groups = "fast", enabled = false, description = "https://github.com/killbill/killbill-commons/issues/4")
+    @Test(groups = "fast", enabled = true, description = "https://github.com/killbill/killbill-commons/issues/4")
     public void testGenerator() throws Exception {
         final DOTBuilder payment = new DOTBuilder("Payment");
-        payment.open(ImmutableMap.of("splines", "false"));
+        payment.open(new TreeMap<>(Map.of("splines", "false")));
 
         payment.openCluster("Retry");
-        final int retryInit = payment.addNode("INIT", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int retrySuccess = payment.addNode("SUCCESS", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int retryFailed = payment.addNode("FAILED", ImmutableMap.of("color", "grey", "style", "filled"));
-        payment.addPath(retryInit, retrySuccess, ImmutableMap.of("label", "\"Op|S\""));
-        payment.addPath(retryInit, retryFailed, ImmutableMap.of("label", "\"Op|F\""));
-        payment.addPath(retryFailed, retryFailed, ImmutableMap.of("label", "\"Op|F\""));
+        final int retryInit = payment.addNode("INIT", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int retrySuccess = payment.addNode("SUCCESS", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int retryFailed = payment.addNode("FAILED", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        payment.addPath(retryInit, retrySuccess, new TreeMap(Map.of("label", "\"Op|S\"")));
+        payment.addPath(retryInit, retryFailed, new TreeMap(Map.of("label", "\"Op|F\"")));
+        payment.addPath(retryFailed, retryFailed, new TreeMap(Map.of("label", "\"Op|F\"")));
         payment.closeCluster();
 
         payment.openCluster("Transaction");
 
         payment.openCluster("Authorize");
-        final int authInit = payment.addNode("INIT", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int authSuccess = payment.addNode("SUCCESS", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int authFailed = payment.addNode("FAILED", ImmutableMap.of("color", "grey", "style", "filled"));
+        final int authInit = payment.addNode("INIT", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int authSuccess = payment.addNode("SUCCESS", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int authFailed = payment.addNode("FAILED", new TreeMap(Map.of("color", "grey", "style", "filled")));
         final int authPending = payment.addNode("PENDING");
-        payment.addPath(authInit, authSuccess, ImmutableMap.of("label", "\"Op|S\""));
-        payment.addPath(authInit, authFailed, ImmutableMap.of("label", "\"Op|F\""));
-        payment.addPath(authInit, authPending, ImmutableMap.of("label", "\"Op|P\""));
-        payment.addPath(authPending, authSuccess, ImmutableMap.of("label", "\"Op|S\""));
-        payment.addPath(authPending, authFailed, ImmutableMap.of("label", "\"Op|F\""));
+        payment.addPath(authInit, authSuccess, new TreeMap(Map.of("label", "\"Op|S\"")));
+        payment.addPath(authInit, authFailed, new TreeMap(Map.of("label", "\"Op|F\"")));
+        payment.addPath(authInit, authPending, new TreeMap(Map.of("label", "\"Op|P\"")));
+        payment.addPath(authPending, authSuccess, new TreeMap(Map.of("label", "\"Op|S\"")));
+        payment.addPath(authPending, authFailed, new TreeMap(Map.of("label", "\"Op|F\"")));
         payment.closeCluster();
 
         payment.openCluster("Capture");
-        final int captureInit = payment.addNode("INIT", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int captureSuccess = payment.addNode("SUCCESS", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int captureFailed = payment.addNode("FAILED", ImmutableMap.of("color", "grey", "style", "filled"));
-        payment.addPath(captureInit, captureSuccess, ImmutableMap.of("label", "\"Op|S\""));
-        payment.addPath(captureInit, captureFailed, ImmutableMap.of("label", "\"Op|F\""));
+        final int captureInit = payment.addNode("INIT", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int captureSuccess = payment.addNode("SUCCESS", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int captureFailed = payment.addNode("FAILED", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        payment.addPath(captureInit, captureSuccess, new TreeMap(Map.of("label", "\"Op|S\"")));
+        payment.addPath(captureInit, captureFailed, new TreeMap(Map.of("label", "\"Op|F\"")));
         payment.closeCluster();
 
         payment.openCluster("Purchase");
-        final int purchaseInit = payment.addNode("INIT", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int purchaseSuccess = payment.addNode("SUCCESS", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int purchaseFailed = payment.addNode("FAILED", ImmutableMap.of("color", "grey", "style", "filled"));
-        payment.addPath(purchaseInit, purchaseSuccess, ImmutableMap.of("label", "\"Op|S\""));
-        payment.addPath(purchaseInit, purchaseFailed, ImmutableMap.of("label", "\"Op|F\""));
+        final int purchaseInit = payment.addNode("INIT", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int purchaseSuccess = payment.addNode("SUCCESS", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int purchaseFailed = payment.addNode("FAILED", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        payment.addPath(purchaseInit, purchaseSuccess, new TreeMap(Map.of("label", "\"Op|S\"")));
+        payment.addPath(purchaseInit, purchaseFailed, new TreeMap(Map.of("label", "\"Op|F\"")));
         payment.closeCluster();
 
         payment.openCluster("Void");
-        final int voidInit = payment.addNode("INIT", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int voidSuccess = payment.addNode("SUCCESS", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int voidFailed = payment.addNode("FAILED", ImmutableMap.of("color", "grey", "style", "filled"));
-        payment.addPath(voidInit, voidSuccess, ImmutableMap.of("label", "\"Op|S\""));
-        payment.addPath(voidInit, voidFailed, ImmutableMap.of("label", "\"Op|F\""));
+        final int voidInit = payment.addNode("INIT", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int voidSuccess = payment.addNode("SUCCESS", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int voidFailed = payment.addNode("FAILED", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        payment.addPath(voidInit, voidSuccess, new TreeMap(Map.of("label", "\"Op|S\"")));
+        payment.addPath(voidInit, voidFailed, new TreeMap(Map.of("label", "\"Op|F\"")));
         payment.closeCluster();
 
         payment.openCluster("Refund");
-        final int refundInit = payment.addNode("INIT", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int refundSuccess = payment.addNode("SUCCESS", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int refundFailed = payment.addNode("FAILED", ImmutableMap.of("color", "grey", "style", "filled"));
-        payment.addPath(refundInit, refundSuccess, ImmutableMap.of("label", "\"Op|S\""));
-        payment.addPath(refundInit, refundFailed, ImmutableMap.of("label", "\"Op|F\""));
+        final int refundInit = payment.addNode("INIT", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int refundSuccess = payment.addNode("SUCCESS", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int refundFailed = payment.addNode("FAILED", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        payment.addPath(refundInit, refundSuccess, new TreeMap(Map.of("label", "\"Op|S\"")));
+        payment.addPath(refundInit, refundFailed, new TreeMap(Map.of("label", "\"Op|F\"")));
         payment.closeCluster();
 
-        payment.addPath(authSuccess, captureInit, ImmutableMap.of("style", "dotted", "label", "CAPTURE_AMOUNT_CHECK"));
-        payment.addPath(authSuccess, voidInit, ImmutableMap.of("style", "dotted"));
-        payment.addPath(captureSuccess, voidInit, ImmutableMap.of("style", "dotted"));
-        payment.addPath(captureSuccess, refundInit, ImmutableMap.of("style", "dotted", "label", "REFUND_AMOUNT_CHECK"));
-        payment.addPath(purchaseSuccess, refundInit, ImmutableMap.of("style", "dotted", "label", "REFUND_AMOUNT_CHECK"));
+        payment.addPath(authSuccess, captureInit, new TreeMap(Map.of("style", "dotted", "label", "CAPTURE_AMOUNT_CHECK")));
+        payment.addPath(authSuccess, voidInit, new TreeMap(Map.of("style", "dotted")));
+        payment.addPath(captureSuccess, voidInit, new TreeMap(Map.of("style", "dotted")));
+        payment.addPath(captureSuccess, refundInit, new TreeMap(Map.of("style", "dotted", "label", "REFUND_AMOUNT_CHECK")));
+        payment.addPath(purchaseSuccess, refundInit, new TreeMap(Map.of("style", "dotted", "label", "REFUND_AMOUNT_CHECK")));
 
         payment.closeCluster(); // Transaction
 
         payment.openCluster("DirectPayment");
 
-        final int directPaymentInit = payment.addNode("INIT", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int directPaymentOpen = payment.addNode("OPEN", ImmutableMap.of("color", "grey", "style", "filled"));
-        final int directPaymentClosed = payment.addNode("CLOSED", ImmutableMap.of("color", "grey", "style", "filled"));
+        final int directPaymentInit = payment.addNode("INIT", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int directPaymentOpen = payment.addNode("OPEN", new TreeMap(Map.of("color", "grey", "style", "filled")));
+        final int directPaymentClosed = payment.addNode("CLOSED", new TreeMap(Map.of("color", "grey", "style", "filled")));
         payment.addPath(directPaymentInit, directPaymentOpen);
         payment.addPath(directPaymentOpen, directPaymentClosed);
 
-        payment.addPath(directPaymentInit, authInit, ImmutableMap.of("style", "dotted", "color", "blue"));
-        payment.addPath(directPaymentInit, purchaseInit, ImmutableMap.of("style", "dotted", "color", "blue"));
-        payment.addPath(directPaymentOpen, authSuccess, ImmutableMap.of("style", "dotted", "color", "green"));
-        payment.addPath(directPaymentOpen, captureSuccess, ImmutableMap.of("style", "dotted", "color", "green"));
-        payment.addPath(directPaymentClosed, refundSuccess, ImmutableMap.of("style", "dotted", "color", "green"));
-        payment.addPath(directPaymentClosed, voidSuccess, ImmutableMap.of("style", "dotted", "color", "green"));
+        payment.addPath(directPaymentInit, authInit, new TreeMap(Map.of("style", "dotted", "color", "blue")));
+        payment.addPath(directPaymentInit, purchaseInit, new TreeMap(Map.of("style", "dotted", "color", "blue")));
+        payment.addPath(directPaymentOpen, authSuccess, new TreeMap(Map.of("style", "dotted", "color", "green")));
+        payment.addPath(directPaymentOpen, captureSuccess, new TreeMap(Map.of("style", "dotted", "color", "green")));
+        payment.addPath(directPaymentClosed, refundSuccess, new TreeMap(Map.of("style", "dotted", "color", "green")));
+        payment.addPath(directPaymentClosed, voidSuccess, new TreeMap(Map.of("style", "dotted", "color", "green")));
 
         payment.closeCluster(); // DirectPayment
 
@@ -118,9 +119,9 @@ public class TestDOTBuilder {
                                                 "    splines=false;\n" +
                                                 "    subgraph cluster_0 {\n" +
                                                 "        label=\"Retry\";\n" +
-                                                "        node_0 [style=filled color=grey label=INIT];\n" +
-                                                "        node_1 [style=filled color=grey label=SUCCESS];\n" +
-                                                "        node_2 [style=filled color=grey label=FAILED];\n" +
+                                                "        node_0 [color=grey style=filled label=INIT];\n" +
+                                                "        node_1 [color=grey style=filled label=SUCCESS];\n" +
+                                                "        node_2 [color=grey style=filled label=FAILED];\n" +
                                                 "        node_0 -> node_1 [label=\"Op|S\"];\n" +
                                                 "        node_0 -> node_2 [label=\"Op|F\"];\n" +
                                                 "        node_2 -> node_2 [label=\"Op|F\"];\n" +
@@ -129,9 +130,9 @@ public class TestDOTBuilder {
                                                 "        label=\"Transaction\";\n" +
                                                 "        subgraph cluster_2 {\n" +
                                                 "            label=\"Authorize\";\n" +
-                                                "            node_3 [style=filled color=grey label=INIT];\n" +
-                                                "            node_4 [style=filled color=grey label=SUCCESS];\n" +
-                                                "            node_5 [style=filled color=grey label=FAILED];\n" +
+                                                "            node_3 [color=grey style=filled label=INIT];\n" +
+                                                "            node_4 [color=grey style=filled label=SUCCESS];\n" +
+                                                "            node_5 [color=grey style=filled label=FAILED];\n" +
                                                 "            node_6 [label=PENDING];\n" +
                                                 "            node_3 -> node_4 [label=\"Op|S\"];\n" +
                                                 "            node_3 -> node_5 [label=\"Op|F\"];\n" +
@@ -141,60 +142,60 @@ public class TestDOTBuilder {
                                                 "        }\n" +
                                                 "        subgraph cluster_3 {\n" +
                                                 "            label=\"Capture\";\n" +
-                                                "            node_7 [style=filled color=grey label=INIT];\n" +
-                                                "            node_8 [style=filled color=grey label=SUCCESS];\n" +
-                                                "            node_9 [style=filled color=grey label=FAILED];\n" +
+                                                "            node_7 [color=grey style=filled label=INIT];\n" +
+                                                "            node_8 [color=grey style=filled label=SUCCESS];\n" +
+                                                "            node_9 [color=grey style=filled label=FAILED];\n" +
                                                 "            node_7 -> node_8 [label=\"Op|S\"];\n" +
                                                 "            node_7 -> node_9 [label=\"Op|F\"];\n" +
                                                 "        }\n" +
                                                 "        subgraph cluster_4 {\n" +
                                                 "            label=\"Purchase\";\n" +
-                                                "            node_10 [style=filled color=grey label=INIT];\n" +
-                                                "            node_11 [style=filled color=grey label=SUCCESS];\n" +
-                                                "            node_12 [style=filled color=grey label=FAILED];\n" +
+                                                "            node_10 [color=grey style=filled label=INIT];\n" +
+                                                "            node_11 [color=grey style=filled label=SUCCESS];\n" +
+                                                "            node_12 [color=grey style=filled label=FAILED];\n" +
                                                 "            node_10 -> node_11 [label=\"Op|S\"];\n" +
                                                 "            node_10 -> node_12 [label=\"Op|F\"];\n" +
                                                 "        }\n" +
                                                 "        subgraph cluster_5 {\n" +
                                                 "            label=\"Void\";\n" +
-                                                "            node_13 [style=filled color=grey label=INIT];\n" +
-                                                "            node_14 [style=filled color=grey label=SUCCESS];\n" +
-                                                "            node_15 [style=filled color=grey label=FAILED];\n" +
+                                                "            node_13 [color=grey style=filled label=INIT];\n" +
+                                                "            node_14 [color=grey style=filled label=SUCCESS];\n" +
+                                                "            node_15 [color=grey style=filled label=FAILED];\n" +
                                                 "            node_13 -> node_14 [label=\"Op|S\"];\n" +
                                                 "            node_13 -> node_15 [label=\"Op|F\"];\n" +
                                                 "        }\n" +
                                                 "        subgraph cluster_6 {\n" +
                                                 "            label=\"Refund\";\n" +
-                                                "            node_16 [style=filled color=grey label=INIT];\n" +
-                                                "            node_17 [style=filled color=grey label=SUCCESS];\n" +
-                                                "            node_18 [style=filled color=grey label=FAILED];\n" +
+                                                "            node_16 [color=grey style=filled label=INIT];\n" +
+                                                "            node_17 [color=grey style=filled label=SUCCESS];\n" +
+                                                "            node_18 [color=grey style=filled label=FAILED];\n" +
                                                 "            node_16 -> node_17 [label=\"Op|S\"];\n" +
                                                 "            node_16 -> node_18 [label=\"Op|F\"];\n" +
                                                 "        }\n" +
-                                                "        node_4 -> node_7 [style=dotted label=CAPTURE_AMOUNT_CHECK];\n" +
+                                                "        node_4 -> node_7 [label=CAPTURE_AMOUNT_CHECK style=dotted];\n" +
                                                 "        node_4 -> node_13 [style=dotted];\n" +
                                                 "        node_8 -> node_13 [style=dotted];\n" +
-                                                "        node_8 -> node_16 [style=dotted label=REFUND_AMOUNT_CHECK];\n" +
-                                                "        node_11 -> node_16 [style=dotted label=REFUND_AMOUNT_CHECK];\n" +
+                                                "        node_8 -> node_16 [label=REFUND_AMOUNT_CHECK style=dotted];\n" +
+                                                "        node_11 -> node_16 [label=REFUND_AMOUNT_CHECK style=dotted];\n" +
                                                 "    }\n" +
                                                 "    subgraph cluster_7 {\n" +
                                                 "        label=\"DirectPayment\";\n" +
-                                                "        node_19 [style=filled color=grey label=INIT];\n" +
-                                                "        node_20 [style=filled color=grey label=OPEN];\n" +
-                                                "        node_21 [style=filled color=grey label=CLOSED];\n" +
+                                                "        node_19 [color=grey style=filled label=INIT];\n" +
+                                                "        node_20 [color=grey style=filled label=OPEN];\n" +
+                                                "        node_21 [color=grey style=filled label=CLOSED];\n" +
                                                 "        node_19 -> node_20;\n" +
                                                 "        node_20 -> node_21;\n" +
-                                                "        node_19 -> node_3 [style=dotted color=blue];\n" +
-                                                "        node_19 -> node_10 [style=dotted color=blue];\n" +
-                                                "        node_20 -> node_4 [style=dotted color=green];\n" +
-                                                "        node_20 -> node_8 [style=dotted color=green];\n" +
-                                                "        node_21 -> node_17 [style=dotted color=green];\n" +
-                                                "        node_21 -> node_14 [style=dotted color=green];\n" +
+                                                "        node_19 -> node_3 [color=blue style=dotted];\n" +
+                                                "        node_19 -> node_10 [color=blue style=dotted];\n" +
+                                                "        node_20 -> node_4 [color=green style=dotted];\n" +
+                                                "        node_20 -> node_8 [color=green style=dotted];\n" +
+                                                "        node_21 -> node_17 [color=green style=dotted];\n" +
+                                                "        node_21 -> node_14 [color=green style=dotted];\n" +
                                                 "    }\n" +
                                                 "}\n");
 
-        //System.out.println(payment.toString());
+        //System.out.println(payment.toString()));
         //System.out.flush();
-        //Files.write((new File("/var/tmp/payment.dot")).toPath(), payment.toString().getBytes());
+        //Files.write((new File("/var/tmp/payment.dot")).toPath(), payment.toString().getBytes()));
     }
 }

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -59,11 +59,6 @@
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>provided</scope>

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/listeners/GuiceServletContextListener.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/listeners/GuiceServletContextListener.java
@@ -19,13 +19,14 @@
 
 package org.killbill.commons.skeleton.listeners;
 
+import java.util.List;
+
 import javax.servlet.ServletContextEvent;
 
+import org.killbill.commons.utils.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -53,7 +54,7 @@ public class GuiceServletContextListener extends com.google.inject.servlet.Guice
     public void contextInitialized(final ServletContextEvent event) {
         // Check if the module was overridden in subclasses
         if (guiceModules == null) {
-            guiceModules = ImmutableList.<Module>of(initializeGuiceModuleFromWebXML(event));
+            guiceModules = List.of(initializeGuiceModuleFromWebXML(event));
         }
 
         super.contextInitialized(event);

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/ResourceTimer.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/metrics/ResourceTimer.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.killbill.commons.metrics.api.MetricRegistry;
 import org.killbill.commons.metrics.api.Timer;
-import com.google.common.base.Joiner;
+import org.killbill.commons.utils.Joiner;
 
 public class ResourceTimer {
 

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/modules/BaseServerModuleBuilder.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/modules/BaseServerModuleBuilder.java
@@ -27,8 +27,6 @@ import java.util.Map;
 import javax.servlet.Filter;
 import javax.servlet.http.HttpServlet;
 
-import com.google.common.collect.Maps;
-
 public class BaseServerModuleBuilder {
 
     public enum JaxrsImplementation {
@@ -38,17 +36,17 @@ public class BaseServerModuleBuilder {
 
     // By default, proxy all requests to the Guice/Jax-RS servlet
     private String jaxrsUriPattern = "/.*";
-    private final Map<String, ArrayList<Map.Entry<Class<? extends Filter>, Map<String, String>>>> filters = new HashMap<String, ArrayList<Map.Entry<Class<? extends Filter>, Map<String, String>>>>();
-    private final Map<String, ArrayList<Map.Entry<Class<? extends Filter>, Map<String, String>>>> filtersRegex = new HashMap<String, ArrayList<Map.Entry<Class<? extends Filter>, Map<String, String>>>>();
-    private final Map<String, Class<? extends HttpServlet>> jaxrsServlets = new HashMap<String, Class<? extends HttpServlet>>();
-    private final Map<String, Class<? extends HttpServlet>> jaxrsServletsRegex = new HashMap<String, Class<? extends HttpServlet>>();
-    private final Map<String, Class<? extends HttpServlet>> servlets = new HashMap<String, Class<? extends HttpServlet>>();
-    private final Map<String, Class<? extends HttpServlet>> servletsRegex = new HashMap<String, Class<? extends HttpServlet>>();
+    private final Map<String, ArrayList<Map.Entry<Class<? extends Filter>, Map<String, String>>>> filters = new HashMap<>();
+    private final Map<String, ArrayList<Map.Entry<Class<? extends Filter>, Map<String, String>>>> filtersRegex = new HashMap<>();
+    private final Map<String, Class<? extends HttpServlet>> jaxrsServlets = new HashMap<>();
+    private final Map<String, Class<? extends HttpServlet>> jaxrsServletsRegex = new HashMap<>();
+    private final Map<String, Class<? extends HttpServlet>> servlets = new HashMap<>();
+    private final Map<String, Class<? extends HttpServlet>> servletsRegex = new HashMap<>();
 
     // Jersey specific
-    private final List<String> jerseyResourcesAndProvidersPackages = new ArrayList<String>();
-    private final List<String> jerseyResourcesAndProvidersClasses = new ArrayList<String>();
-    private final Map<String, String> jerseyParams = new HashMap<String, String>();
+    private final List<String> jerseyResourcesAndProvidersPackages = new ArrayList<>();
+    private final List<String> jerseyResourcesAndProvidersClasses = new ArrayList<>();
+    private final Map<String, String> jerseyParams = new HashMap<>();
 
     private JaxrsImplementation jaxrsImplementation = JaxrsImplementation.JERSEY;
 
@@ -56,28 +54,28 @@ public class BaseServerModuleBuilder {
     }
 
     public BaseServerModuleBuilder addFilter(final String urlPattern, final Class<? extends Filter> filterKey) {
-        return addFilter(urlPattern, filterKey, new HashMap<String, String>());
+        return addFilter(urlPattern, filterKey, new HashMap<>());
     }
 
     public BaseServerModuleBuilder addFilter(final String urlPattern, final Class<? extends Filter> filterKey, final Map<String, String> initParams) {
         if (this.filters.get(urlPattern) == null) {
-            this.filters.put(urlPattern, new ArrayList<Map.Entry<Class<? extends Filter>, Map<String, String>>>());
+            this.filters.put(urlPattern, new ArrayList<>());
         }
 
-        this.filters.get(urlPattern).add(Maps.<Class<? extends Filter>, Map<String, String>>immutableEntry(filterKey, initParams));
+        this.filters.get(urlPattern).add(Map.entry(filterKey, initParams));
         return this;
     }
 
     public BaseServerModuleBuilder addFilterRegex(final String urlPattern, final Class<? extends Filter> filterKey) {
-        return addFilterRegex(urlPattern, filterKey, new HashMap<String, String>());
+        return addFilterRegex(urlPattern, filterKey, new HashMap<>());
     }
 
     public BaseServerModuleBuilder addFilterRegex(final String urlPattern, final Class<? extends Filter> filterKey, final Map<String, String> initParams) {
         if (this.filtersRegex.get(urlPattern) == null) {
-            this.filtersRegex.put(urlPattern, new ArrayList<Map.Entry<Class<? extends Filter>, Map<String, String>>>());
+            this.filtersRegex.put(urlPattern, new ArrayList<>());
         }
 
-        this.filtersRegex.get(urlPattern).add(Maps.<Class<? extends Filter>, Map<String, String>>immutableEntry(filterKey, initParams));
+        this.filtersRegex.get(urlPattern).add(Map.entry(filterKey, initParams));
         return this;
     }
 

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/modules/ConfigModule.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/modules/ConfigModule.java
@@ -19,13 +19,14 @@
 
 package org.killbill.commons.skeleton.modules;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import org.skife.config.ConfigSource;
 import org.skife.config.ConfigurationObjectFactory;
 import org.skife.config.SimplePropertyConfigSource;
 
-import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 
 public class ConfigModule extends AbstractModule {
@@ -38,15 +39,15 @@ public class ConfigModule extends AbstractModule {
     }
 
     public ConfigModule(final Properties properties) {
-        this(ImmutableList.<Class>of(), new SimplePropertyConfigSource(properties));
+        this(Collections.emptyList(), new SimplePropertyConfigSource(properties));
     }
 
     public ConfigModule(final Class config) {
-        this(ImmutableList.<Class>of(config));
+        this(List.of(config));
     }
 
     public ConfigModule(final Class... configs) {
-        this(ImmutableList.<Class>copyOf(configs));
+        this(List.of(configs));
     }
 
     public ConfigModule(final Iterable<Class> configs) {

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/modules/GuiceServletContainer.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/modules/GuiceServletContainer.java
@@ -17,6 +17,8 @@
 
 package org.killbill.commons.skeleton.modules;
 
+import java.util.Set;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.servlet.ServletException;
@@ -32,13 +34,10 @@ import org.glassfish.jersey.spi.ExceptionMappers;
 import org.jvnet.hk2.guice.bridge.api.GuiceBridge;
 import org.jvnet.hk2.guice.bridge.api.GuiceIntoHK2Bridge;
 import org.killbill.commons.metrics.api.MetricRegistry;
+import org.killbill.commons.utils.Strings;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 import com.google.inject.TypeLiteral;
 
@@ -69,12 +68,11 @@ public class GuiceServletContainer extends ServletContainer {
         // Metrics integration
         final String scannedResourcePackagesString = webConfig.getInitParameter(ServerProperties.PROVIDER_PACKAGES);
         if (Strings.emptyToNull(scannedResourcePackagesString) != null) {
-            final ImmutableSet<String> scannedResourcePackages = ImmutableSet.<String>copyOf(Splitter.on(CharMatcher.anyOf(" ,;\n"))
-                                                                                                     .split(scannedResourcePackagesString));
+            final Set<String> scannedResourcePackages = Set.of(scannedResourcePackagesString.split("[ ,;\n]"));
             ServiceLocatorUtilities.addOneConstant(serviceLocator,
                                                    new TimedInterceptionService(scannedResourcePackages,
                                                                                 // From HK2
-                                                                                injectionManager.<ExceptionMappers>getInstance(ExceptionMappers.class),
+                                                                                injectionManager.getInstance(ExceptionMappers.class),
                                                                                 // From Guice
                                                                                 injector.getInstance(MetricRegistry.class)));
         }
@@ -84,7 +82,7 @@ public class GuiceServletContainer extends ServletContainer {
         if (hasObjectMapperBinding) {
             // JacksonJsonProvider is constructed by HK2, but we need to inject the ObjectMapper we constructed via Guice
             final ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
-            for (final MessageBodyWriter messageBodyWriter : injectionManager.<MessageBodyWriter>getAllInstances(MessageBodyWriter.class)) {
+            for (final MessageBodyWriter<?> messageBodyWriter : injectionManager.<MessageBodyWriter<?>>getAllInstances(MessageBodyWriter.class)) {
                 if (messageBodyWriter instanceof JacksonJsonProvider) {
                     ((JacksonJsonProvider) messageBodyWriter).setMapper(objectMapper);
                     break;

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/modules/JMXModule.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/modules/JMXModule.java
@@ -20,33 +20,34 @@
 package org.killbill.commons.skeleton.modules;
 
 import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.List;
 
 import javax.management.MBeanServer;
 
 import org.weakref.jmx.guice.ExportBinder;
 import org.weakref.jmx.guice.MBeanModule;
 
-import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 
 public class JMXModule extends AbstractModule {
 
     // JMX beans to export
-    private final Iterable<Class> beans;
+    private final Iterable<Class<?>> beans;
 
     public JMXModule() {
-        this(ImmutableList.<Class>of());
+        this(Collections.emptyList());
     }
 
-    public JMXModule(final Class bean) {
-        this(ImmutableList.<Class>of(bean));
+    public JMXModule(final Class<?> bean) {
+        this(List.of(bean));
     }
 
-    public JMXModule(final Class... beans) {
-        this(ImmutableList.<Class>copyOf(beans));
+    public JMXModule(final Class<?>... beans) {
+        this(List.of(beans));
     }
 
-    public JMXModule(final Iterable<Class> beans) {
+    public JMXModule(final Iterable<Class<?>> beans) {
         this.beans = beans;
     }
 
@@ -58,7 +59,7 @@ public class JMXModule extends AbstractModule {
         install(new MBeanModule());
 
         final ExportBinder builder = ExportBinder.newExporter(binder());
-        for (final Class beanClass : beans) {
+        for (final Class<?> beanClass : beans) {
             builder.export(beanClass).withGeneratedName();
         }
     }

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/modules/TimedInterceptionService.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/modules/TimedInterceptionService.java
@@ -37,7 +37,6 @@ import org.killbill.commons.metrics.api.annotation.TimedResource;
 import org.killbill.commons.skeleton.metrics.TimedResourceInterceptor;
 
 import org.killbill.commons.metrics.api.MetricRegistry;
-import com.google.common.collect.ImmutableList;
 
 @Singleton
 public class TimedInterceptionService implements InterceptionService {
@@ -99,7 +98,7 @@ public class TimedInterceptionService implements InterceptionService {
                                                                                         resourcePath,
                                                                                         metricName,
                                                                                         httpMethod.value());
-        return ImmutableList.<MethodInterceptor>of(timedResourceInterceptor);
+        return List.of(timedResourceInterceptor);
     }
 
     private HttpMethod resourceHttpMethod(final Method method) {

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TestResourceTimer.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TestResourceTimer.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.killbill.commons.metrics.api.MetricRegistry;
 import org.killbill.commons.metrics.api.Timer;
-import com.google.common.collect.ImmutableMap;
 
 import org.killbill.commons.metrics.dropwizard.KillBillCodahaleMetricRegistry;
 import org.testng.Assert;
@@ -72,7 +71,7 @@ public class TestResourceTimer {
         final String escapeResourcePath = "/1_0/kb/payments";
         final String resourceName = "create";
         final String httpMethod = "POST";
-        final Map<String, Object> tags = ImmutableMap.<String, Object>builder().put("transactionType", "AUTHORIZE").build();
+        final Map<String, Object> tags = Map.of("transactionType", "AUTHORIZE");
 
         final ResourceTimer resourceTimer = new ResourceTimer(resourcePath, resourceName, httpMethod, tags, metricRegistry);
         resourceTimer.update(501, 1, TimeUnit.MILLISECONDS);

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TestTimedResourceInterceptor.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/metrics/TestTimedResourceInterceptor.java
@@ -22,6 +22,7 @@ package org.killbill.commons.skeleton.metrics;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.List;
+import java.util.Set;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -43,7 +44,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -199,7 +199,7 @@ public class TestTimedResourceInterceptor {
             final MetricRegistry metricRegistry = new KillBillCodahaleMetricRegistry();
             bind(MetricRegistry.class).toInstance(metricRegistry);
 
-            final InterceptionService timedInterceptionService = new TimedInterceptionService(ImmutableSet.<String>of(this.getClass().getPackage().getName()),
+            final InterceptionService timedInterceptionService = new TimedInterceptionService(Set.of(this.getClass().getPackage().getName()),
                                                                                               Mockito.mock(ExceptionMappers.class),
                                                                                               metricRegistry);
             bindListener(Matchers.any(), new TypeListener() {

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/modules/HelloResource.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/modules/HelloResource.java
@@ -33,7 +33,6 @@ import org.joda.time.LocalDate;
 import org.killbill.commons.metrics.api.annotation.TimedResource;
 import org.testng.Assert;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 
 @Path("hello")
@@ -64,6 +63,6 @@ public class HelloResource {
     @POST
     @Produces("application/json")
     public Map<String, ?> hello() {
-        return ImmutableMap.<String, Object>of("key", "hello", "date", new LocalDate("2010-01-01"));
+        return Map.of("key", "hello", "date", new LocalDate("2010-01-01"));
     }
 }

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/modules/TestJerseyBaseServerModule.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/modules/TestJerseyBaseServerModule.java
@@ -98,11 +98,10 @@ public class TestJerseyBaseServerModule extends AbstractBaseServerModuleTest {
 
         request = HttpRequest.newBuilder().uri(URI.create("http://127.0.0.1:" + ((NetworkConnector) server.getConnectors()[0]).getPort() + "/hello")).POST(HttpRequest.BodyPublishers.noBody()).build();
         body = client.send(request, BodyHandlers.ofString()).body();
-        // Assertion was:
-        // Assert.assertEquals(body, "{\"key\":\"hello\",\"date\":\"2010-01-01\"}");
-        // Before #1615, HelloResource response was produced using ImmutableMap that maintains insertion order.
+
         final ObjectMapper objectMapper = new ObjectMapper();
         final JsonNode node = objectMapper.readTree(body);
+
         Assert.assertEquals(node.get("key").textValue(), "hello");
         Assert.assertEquals(node.get("date").textValue(), "2010-01-01");
 

--- a/skeleton/src/test/java/org/killbill/commons/skeleton/modules/TestJerseyBaseServerModule.java
+++ b/skeleton/src/test/java/org/killbill/commons/skeleton/modules/TestJerseyBaseServerModule.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jetty.server.NetworkConnector;
@@ -41,7 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-import com.google.common.collect.ImmutableList;
+
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -57,7 +58,7 @@ public class TestJerseyBaseServerModule extends AbstractBaseServerModuleTest {
         builder.setJaxrsUriPattern("/hello|/hello/.*");
 
         final Injector injector = Guice.createInjector(builder.build(),
-                                                       new StatsModule(healthCheckUri, metricsUri, threadsUri, ImmutableList.<Class<? extends HealthCheck>>of(TestHealthCheck.class)),
+                                                       new StatsModule(healthCheckUri, metricsUri, threadsUri, List.of(TestHealthCheck.class)),
                                                        new AbstractModule() {
                                                            @Override
                                                            protected void configure() {
@@ -108,7 +109,7 @@ public class TestJerseyBaseServerModule extends AbstractBaseServerModuleTest {
     public void testJerseyParams() throws Exception {
         final BaseServerModuleBuilder builder1 = new BaseServerModuleBuilder();
         final JerseyBaseServerModule module1 = (JerseyBaseServerModule) builder1.build();
-        final Map<String, String> jerseyParams1 = module1.getJerseyParams().build();
+        final Map<String, String> jerseyParams1 = module1.getJerseyParams();
         Assert.assertEquals(jerseyParams1.size(), 2);
         Assert.assertEquals(jerseyParams1.get(JerseyBaseServerModule.JERSEY_LOGGING_VERBOSITY), "HEADERS_ONLY");
         Assert.assertEquals(jerseyParams1.get(JerseyBaseServerModule.JERSEY_LOGGING_LEVEL), "INFO");
@@ -118,7 +119,7 @@ public class TestJerseyBaseServerModule extends AbstractBaseServerModuleTest {
                 .addJerseyParam(JerseyBaseServerModule.JERSEY_LOGGING_LEVEL, "FINE")
                 .addJerseyParam("foo", "qux");
         final JerseyBaseServerModule module2 = (JerseyBaseServerModule) builder2.build();
-        final Map<String, String> jerseyParams2 = module2.getJerseyParams().build();
+        final Map<String, String> jerseyParams2 = module2.getJerseyParams();
         Assert.assertEquals(jerseyParams2.size(), 3);
         Assert.assertEquals(jerseyParams2.get(JerseyBaseServerModule.JERSEY_LOGGING_VERBOSITY), "PAYLOAD_TEXT");
         Assert.assertEquals(jerseyParams2.get(JerseyBaseServerModule.JERSEY_LOGGING_LEVEL), "FINE");

--- a/utils/src/main/java/org/killbill/commons/utils/collect/EvictingQueue.java
+++ b/utils/src/main/java/org/killbill/commons/utils/collect/EvictingQueue.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2012 The Guava Authors
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.utils.collect;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+import org.killbill.commons.utils.Preconditions;
+
+/**
+ * Replacement of Guava {@code EvictingQueue}, some behavior may different from original one.
+ */
+public class EvictingQueue<E> implements Queue<E> {
+
+    private final int maxSize;
+    private final Queue<E> delegate;
+
+    public EvictingQueue(final int maxSize) {
+        this.maxSize = maxSize;
+        this.delegate = new ArrayDeque<>();
+    }
+
+    /**
+     * Returns the number of additional elements that this queue can accept without evicting; zero if
+     * the queue is currently full.
+     */
+    public int remainingCapacity() {
+        return maxSize - size();
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean contains(final Object o) {
+        return delegate.contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return delegate.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(final T[] array) {
+        return delegate.toArray(array);
+    }
+
+    @Override
+    public boolean add(final E element) {
+        Preconditions.checkNotNull(element);
+        if (maxSize == 0) {
+            return true;
+        }
+        if (size() == maxSize) {
+            delegate.remove();
+        }
+        delegate.add(element);
+        return true;
+    }
+
+    @Override
+    public boolean remove(final Object o) {
+        return delegate.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(final Collection<?> collection) {
+        return delegate.containsAll(collection);
+    }
+
+    // Different implementation from original EvictingQueue.
+    @Override
+    public boolean addAll(final Collection<? extends E> collection) {
+        if (collection.isEmpty()) {
+            return false;
+        }
+        final int size = collection.size();
+        if (size >= maxSize) {
+            clear();
+            collection.stream()
+                      .skip(size - maxSize)
+                      .collect(Collectors.toUnmodifiableList())
+                      .forEach(this::add);
+        } else {
+            collection.forEach(this::add);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean removeAll(final Collection<?> c) {
+        return delegate.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(final Collection<?> c) {
+        return delegate.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    public boolean offer(final E e) {
+        return add(e);
+    }
+
+    @Override
+    public E remove() {
+        return delegate.remove();
+    }
+
+    @Override
+    public E poll() {
+        return delegate.poll();
+    }
+
+    @Override
+    public E element() {
+        return delegate.element();
+    }
+
+    @Override
+    public E peek() {
+        return delegate.peek();
+    }
+}

--- a/utils/src/test/java/org/killbill/commons/utils/collect/TestEvictingQueue.java
+++ b/utils/src/test/java/org/killbill/commons/utils/collect/TestEvictingQueue.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.utils.collect;
+
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestEvictingQueue {
+
+    private static final int MAX_SIZE = 100;
+
+    private EvictingQueue<Integer> createEvictingQueue() {
+        final EvictingQueue<Integer> result = new EvictingQueue<>(MAX_SIZE);
+        for (int i = 0; i < (MAX_SIZE - 3); i++) {
+            result.add(i);
+        }
+        return result;
+    }
+
+    @Test(groups = "fast", description = "Test several methods to make it more useful")
+    public void testAddPeekSizeContains() {
+        final EvictingQueue<Integer> evictingQueue = createEvictingQueue();
+
+        Assert.assertEquals(evictingQueue.peek(), 0);
+
+        evictingQueue.add(201);
+
+        Assert.assertEquals(evictingQueue.size(), 98);
+        Assert.assertEquals(evictingQueue.peek(), 0); // Peek keep 0 (not reached limit)
+        Assert.assertTrue(evictingQueue.contains(0));
+        Assert.assertTrue(evictingQueue.contains(1));
+
+        evictingQueue.add(202);
+        evictingQueue.add(203);
+
+        Assert.assertEquals(evictingQueue.size(), MAX_SIZE);
+        Assert.assertEquals(evictingQueue.peek(), 0); // Peek keep 0 (not reached limit)
+        Assert.assertTrue(evictingQueue.contains(0));
+        Assert.assertTrue(evictingQueue.contains(1));
+
+        evictingQueue.add(204);
+        evictingQueue.add(205);
+
+        Assert.assertEquals(evictingQueue.size(), MAX_SIZE);
+        Assert.assertEquals(evictingQueue.peek(), 2); // (reach limit peek changes)
+        Assert.assertFalse(evictingQueue.contains(0));
+        Assert.assertFalse(evictingQueue.contains(1));
+        Assert.assertTrue(evictingQueue.contains(2));
+        Assert.assertTrue(evictingQueue.contains(3));
+
+        evictingQueue.add(206);
+        evictingQueue.add(207);
+
+        Assert.assertEquals(evictingQueue.size(), MAX_SIZE);
+        Assert.assertEquals(evictingQueue.peek(), 4); // (reach limit peek changes)
+        Assert.assertFalse(evictingQueue.contains(2));
+        Assert.assertFalse(evictingQueue.contains(3));
+        Assert.assertTrue(evictingQueue.contains(4));
+        Assert.assertTrue(evictingQueue.contains(5));
+    }
+
+    @Test(groups = "fast")
+    public void testRemainingCapacity() {
+        final EvictingQueue<Integer> evictingQueue = createEvictingQueue();
+
+        evictingQueue.add(201);
+        Assert.assertEquals(evictingQueue.remainingCapacity(), 2);
+
+        evictingQueue.add(202);
+        Assert.assertEquals(evictingQueue.remainingCapacity(), 1);
+
+        evictingQueue.add(203);
+        Assert.assertEquals(evictingQueue.remainingCapacity(), 0);
+
+        evictingQueue.clear();
+
+        Assert.assertEquals(evictingQueue.remainingCapacity(), 100);
+    }
+
+    @Test(groups = "fast")
+    public void testAddAll() {
+        final EvictingQueue<Integer> evictingQueue = createEvictingQueue();
+        evictingQueue.addAll(List.of(201, 202));
+
+        Assert.assertEquals(evictingQueue.size(), 99);
+        Assert.assertEquals(evictingQueue.remainingCapacity(), 1);
+
+        evictingQueue.add(100);
+
+        Assert.assertEquals(evictingQueue.size(), 100);
+        Assert.assertEquals(evictingQueue.remainingCapacity(), 0);
+
+        evictingQueue.addAll(List.of(204, 205, 206));
+
+        Assert.assertEquals(evictingQueue.size(), 100);
+        Assert.assertEquals(evictingQueue.remainingCapacity(), 0);
+    }
+}

--- a/xmlloader/pom.xml
+++ b/xmlloader/pom.xml
@@ -33,10 +33,6 @@
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>runtime</scope>
@@ -59,6 +55,10 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/xmlloader/src/main/java/org/killbill/xmlloader/UriAccessor.java
+++ b/xmlloader/src/main/java/org/killbill/xmlloader/UriAccessor.java
@@ -28,7 +28,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Scanner;
 
-import com.google.common.io.Resources;
+import org.killbill.commons.utils.io.Resources;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/xmlloader/src/test/java/org/killbill/xmlloader/TestXMLSchemaGenerator.java
+++ b/xmlloader/src/test/java/org/killbill/xmlloader/TestXMLSchemaGenerator.java
@@ -26,7 +26,7 @@ import java.io.InputStreamReader;
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerException;
 
-import com.google.common.io.CharStreams;
+import org.killbill.commons.utils.io.CharStreams;
 import org.testng.annotations.Test;
 
 public class TestXMLSchemaGenerator  {


### PR DESCRIPTION
This is the last PR for #1615 work in `killbill-commons` repository. After this, `killbill-commons` will be Guava-free. Notes:

1. `DefaultStateMachine` line ~164 : Refactor from `IllegalStateException` to `NoSuchElementException`, otherwise `TestStateMachine` failed. This is caused by `Optional#get()` in Guava and java 8 throw different exception.

2. `DefaultStateMachineConfig` line ~121 : Refactor from `IllegalStateException` to `NoSuchElementException` . Same reason as point 1.