### PR TITLE
1615 remove guice and update oss

### DIFF
--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -79,6 +79,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M7</version>
                         <configuration>
                             <groups>org.skife.config.ConfigMagicTests</groups>
                         </configuration>
@@ -86,7 +87,7 @@
                             <dependency>
                                 <groupId>org.apache.maven.surefire</groupId>
                                 <artifactId>surefire-junit47</artifactId>
-                                <version>3.0.0-M6</version>
+                                <version>3.0.0-M7</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -234,6 +234,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M7</version>
                         <configuration>
                             <groups>org.skife.jdbi.v2.JDBITests</groups>
                             <excludes>
@@ -245,7 +246,7 @@
                             <dependency>
                                 <groupId>org.apache.maven.surefire</groupId>
                                 <artifactId>surefire-junit47</artifactId>
-                                <version>3.0.0-M6</version>
+                                <version>3.0.0-M7</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -52,11 +52,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
@@ -72,6 +67,10 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DBIProvider.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/guice/DBIProvider.java
@@ -22,6 +22,9 @@ package org.killbill.commons.jdbi.guice;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.sql.DataSource;
 
 import org.killbill.commons.jdbi.argument.DateTimeArgumentFactory;
@@ -43,9 +46,6 @@ import org.skife.jdbi.v2.tweak.TransactionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-
 public class DBIProvider implements Provider<IDBI> {
 
     private static final Logger logger = LoggerFactory.getLogger(DBIProvider.class);
@@ -53,9 +53,9 @@ public class DBIProvider implements Provider<IDBI> {
     private final DaoConfig config;
     private final DataSource ds;
     private final TransactionHandler transactionHandler;
-    private final Set<ArgumentFactory> argumentFactorySet = new LinkedHashSet<ArgumentFactory>();
-    private final Set<ResultSetMapperFactory> resultSetMapperFactorySet = new LinkedHashSet<ResultSetMapperFactory>();
-    private final Set<ResultSetMapper> resultSetMapperSet = new LinkedHashSet<ResultSetMapper>();
+    private final Set<ArgumentFactory> argumentFactorySet = new LinkedHashSet<>();
+    private final Set<ResultSetMapperFactory> resultSetMapperFactorySet = new LinkedHashSet<>();
+    private final Set<ResultSetMapper> resultSetMapperSet = new LinkedHashSet<>();
 
     private SQLLog sqlLog;
     private TimingCollector timingCollector;
@@ -71,44 +71,44 @@ public class DBIProvider implements Provider<IDBI> {
         setDefaultResultSetMapperSet();
     }
 
-    @Inject(optional = true)
-    public void setArgumentFactorySet(final Set<ArgumentFactory> argumentFactorySet) {
-        for (final ArgumentFactory argumentFactory : argumentFactorySet) {
-            this.argumentFactorySet.add(argumentFactory);
+    @Inject
+    public void setArgumentFactorySet(@Nullable final Set<ArgumentFactory> argumentFactorySet) {
+        if (argumentFactorySet != null) {
+            this.argumentFactorySet.addAll(argumentFactorySet);
         }
     }
 
-    @Inject(optional = true)
-    public void setResultSetMapperFactorySet(final Set<ResultSetMapperFactory> resultSetMapperFactorySet) {
-        for (final ResultSetMapperFactory resultSetMapperFactory : resultSetMapperFactorySet) {
-            this.resultSetMapperFactorySet.add(resultSetMapperFactory);
+    @Inject
+    public void setResultSetMapperFactorySet(@Nullable final Set<ResultSetMapperFactory> resultSetMapperFactorySet) {
+        if (resultSetMapperFactorySet != null) {
+            this.resultSetMapperFactorySet.addAll(resultSetMapperFactorySet);
         }
     }
 
-    @Inject(optional = true)
-    public void setResultSetMapperSet(final Set<ResultSetMapper> resultSetMapperSet) {
-        for (final ResultSetMapper resultSetMapper : resultSetMapperSet) {
-            this.resultSetMapperSet.add(resultSetMapper);
+    @Inject
+    public void setResultSetMapperSet(@Nullable final Set<ResultSetMapper> resultSetMapperSet) {
+        if (resultSetMapperSet != null) {
+            this.resultSetMapperSet.addAll(resultSetMapperSet);
         }
     }
 
-    @Inject(optional = true)
-    public void setSqlLog(final SQLLog sqlLog) {
+    @Inject
+    public void setSqlLog(@Nullable final SQLLog sqlLog) {
         this.sqlLog = sqlLog;
     }
 
-    @Inject(optional = true)
-    public void setTimingCollector(final TimingCollector timingCollector) {
+    @Inject
+    public void setTimingCollector(@Nullable final TimingCollector timingCollector) {
         this.timingCollector = timingCollector;
     }
 
-    @Inject(optional = true)
-    public void setStatementRewriter(final StatementRewriter statementRewriter) {
+    @Inject
+    public void setStatementRewriter(@Nullable final StatementRewriter statementRewriter) {
         this.statementRewriter = statementRewriter;
     }
 
-    @Inject(optional = true)
-    public void setStatementBuilderFactory(final StatementBuilderFactory statementBuilderFactory) {
+    @Inject
+    public void setStatementBuilderFactory(@Nullable final StatementBuilderFactory statementBuilderFactory) {
         this.statementBuilderFactory = statementBuilderFactory;
     }
 

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/metrics/src/main/java/org/killbill/commons/metrics/health/KillBillHealthCheckRegistry.java
+++ b/metrics/src/main/java/org/killbill/commons/metrics/health/KillBillHealthCheckRegistry.java
@@ -24,14 +24,14 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import javax.inject.Inject;
+
 import org.killbill.commons.health.api.HealthCheck;
 import org.killbill.commons.health.api.HealthCheckRegistry;
 import org.killbill.commons.health.api.Result;
 import org.killbill.commons.health.impl.UnhealthyResultBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.inject.Inject;
 
 public class KillBillHealthCheckRegistry implements HealthCheckRegistry {
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-adc0387-SNAPSHOT</version>
+        <version>0.145.3-17b5048-SNAPSHOT</version>
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>


### PR DESCRIPTION
- `DBIProvider` and `KillBillHealthCheckRegistry` still use Guice `@Inject` annotation
- remove unused dependency
- update `killbill-oss-version`, in attempt to fix `killbill` repository build.