### PR TITLE
115 address spotbugs config magic

### DIFF
--- a/config-magic/src/main/java/org/skife/config/ConfigurationObjectFactory.java
+++ b/config-magic/src/main/java/org/skife/config/ConfigurationObjectFactory.java
@@ -25,13 +25,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.DynamicType.Builder;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
@@ -68,7 +68,6 @@ public class ConfigurationObjectFactory {
         return internalBuild(configClass, null);
     }
 
-    @SuppressFBWarnings("RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED")
     private <T> T internalBuild(final Class<T> configClass, @Nullable final Map<String, String> mappedReplacements) {
         Builder<T> bbBuilder = new ByteBuddy().subclass(configClass);
 
@@ -211,11 +210,10 @@ public class ConfigurationObjectFactory {
         }
     }
 
-    @SuppressFBWarnings("WMI_WRONG_MAP_ITERATOR")
     private String applyReplacements(String propertyName, final Map<String, String> mappedReplacements) {
-        for (final String key : mappedReplacements.keySet()) {
-            final String token = makeToken(key);
-            final String replacement = mappedReplacements.get(key);
+        for (final Entry<String, String> entry : mappedReplacements.entrySet()) {
+            final String token = makeToken(entry.getKey());
+            final String replacement = entry.getValue();
             propertyName = propertyName.replace(token, replacement);
         }
         return propertyName;

--- a/config-magic/src/main/java/org/skife/config/SimplePropertyConfigSource.java
+++ b/config-magic/src/main/java/org/skife/config/SimplePropertyConfigSource.java
@@ -19,15 +19,12 @@ package org.skife.config;
 
 import java.util.Properties;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class SimplePropertyConfigSource implements ConfigSource {
 
     private final Properties props;
 
     public SimplePropertyConfigSource(final Properties props) {
-        this.props = props;
+        this.props = new Properties(props);
     }
 
     public String getString(final String propertyName) {


### PR DESCRIPTION
Related issue: https://github.com/killbill/killbill-commons/issues/113

- All modification explained in each commit. 
- Leave `NP_BOOLEAN_RETURN_NULL` in `DefaultCoercibles.BOOLEAN_COERCER`, because I assume that this is should be failed (and throw exception) if user set something like `some.other.config.useReadDb=Truer`