### PR TITLE
address spotbugs in embeddeddb

### DIFF
--- a/embeddeddb/common/src/main/java/org/killbill/commons/embeddeddb/EmbeddedDB.java
+++ b/embeddeddb/common/src/main/java/org/killbill/commons/embeddeddb/EmbeddedDB.java
@@ -38,7 +38,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public abstract class EmbeddedDB {
 
     protected static final Logger logger = LoggerFactory.getLogger(EmbeddedDB.class);
@@ -56,7 +55,7 @@ public abstract class EmbeddedDB {
     protected String jdbcConnectionString;
     protected DataSource dataSource;
 
-    protected List<String> allTables = new LinkedList<String>();
+    protected List<String> allTables = new LinkedList<>();
 
     protected EmbeddedDB(final String databaseName, final String username, final String password, final String jdbcConnectionString) {
         this.databaseName = databaseName;
@@ -77,11 +76,13 @@ public abstract class EmbeddedDB {
 
     public abstract void refreshTableNames() throws IOException;
 
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public DataSource getDataSource() throws IOException {
         return dataSource;
     }
 
     // Delayed initialization for GenericStandaloneDB
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public void setDataSource(final DataSource dataSource) {
         this.dataSource = dataSource;
     }
@@ -115,7 +116,7 @@ public abstract class EmbeddedDB {
     }
 
     public List<String> getAllTables() {
-        return allTables;
+        return List.copyOf(allTables);
     }
 
     private static final Pattern WHITESPACE_ONLY = Pattern.compile("^\\s*$");

--- a/embeddeddb/h2/pom.xml
+++ b/embeddeddb/h2/pom.xml
@@ -29,10 +29,6 @@
     <name>Kill Bill library of embedded dbs: H2</name>
     <dependencies>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>


### PR DESCRIPTION
Related issue: https://github.com/killbill/killbill-commons/issues/113

- apply to `embeddeddb` and all submodules.
- All modification explained in each commit. 
- Leave `EmbeddedDB.datasource` as is, with `EI_EXPOSE_REP` in getter and `EI_EXPOSE_REP2` in its setter.