### PR TITLE
remove spotbugs warning in jdbi module

### DIFF
--- a/jdbi/src/main/java/org/killbill/commons/jdbi/mapper/LowerToCamelBeanMapper.java
+++ b/jdbi/src/main/java/org/killbill/commons/jdbi/mapper/LowerToCamelBeanMapper.java
@@ -44,14 +44,12 @@ import org.killbill.commons.utils.Strings;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 // Identical to org.skife.jdbi.v2.BeanMapper but maps created_date to createdDate
 public class LowerToCamelBeanMapper<T> implements ResultSetMapper<T> {
 
     private final Class<T> type;
     private final Map<String, PropertyDescriptor> properties = new HashMap<>();
-    private final Map<String, PropertyMapper> propertiesMappers = new HashMap<>();
+    private final Map<String, PropertyMapper<ResultSet, ?>> propertiesMappers = new HashMap<>();
 
     public LowerToCamelBeanMapper(final Class<T> type) {
         this.type = type;
@@ -62,158 +60,7 @@ public class LowerToCamelBeanMapper<T> implements ResultSetMapper<T> {
                 final String key = Strings.toSnakeCase(descriptor.getName()).toLowerCase();
                 properties.put(key, descriptor);
 
-                final PropertyMapper propertyMapper;
-                final Class<?> propertyType = descriptor.getPropertyType();
-                if (propertyType.isAssignableFrom(Boolean.class) || propertyType.isAssignableFrom(boolean.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, Boolean>() {
-
-                        @Override
-                        public Boolean apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getBoolean(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(Byte.class) || propertyType.isAssignableFrom(byte.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, Byte>() {
-
-                        @Override
-                        public Byte apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getByte(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(Short.class) || propertyType.isAssignableFrom(short.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, Short>() {
-
-                        @Override
-                        public Short apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getShort(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(Integer.class) || propertyType.isAssignableFrom(int.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, Integer>() {
-
-                        @Override
-                        public Integer apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getInt(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(Long.class) || propertyType.isAssignableFrom(long.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, Long>() {
-
-                        @Override
-                        public Long apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getLong(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(Float.class) || propertyType.isAssignableFrom(float.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, Float>() {
-
-                        @Override
-                        public Float apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getFloat(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(Double.class) || propertyType.isAssignableFrom(double.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, Double>() {
-
-                        @Override
-                        public Double apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getDouble(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(BigDecimal.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, BigDecimal>() {
-
-                        @Override
-                        public BigDecimal apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getBigDecimal(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(DateTime.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, DateTime>() {
-
-                        @Override
-                        public DateTime apply(final ResultSet rs, final int i) throws SQLException {
-                            final Timestamp timestamp = rs.getTimestamp(i);
-                            return timestamp == null ? null : new DateTime(timestamp).toDateTime(DateTimeZone.UTC);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(Time.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, Time>() {
-
-                        @Override
-                        public Time apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getTime(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(LocalDate.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, LocalDate>() {
-
-                        @Override
-                        public LocalDate apply(final ResultSet rs, final int i) throws SQLException {
-                            //
-                            // We store the LocalDate into a mysql 'date' as a string
-                            // (See https://github.com/killbill/killbill-commons/blob/master/jdbi/src/main/java/org/killbill/commons/jdbi/argument/LocalDateArgumentFactory.java)
-                            // So we also read it as a String which avoids any kind of transformation
-                            //
-                            // Note that we used previously the getDate(index, Calendar) method, but this is not thread safe as we discovered
-                            // unless maybe -- untested --we pass a new instance of a Calendar each time
-                            //
-                            final String dateString = rs.getString(i);
-                            return dateString == null ? null : new LocalDate(dateString, DateTimeZone.UTC);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(DateTimeZone.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, DateTimeZone>() {
-
-                        @Override
-                        public DateTimeZone apply(final ResultSet rs, final int i) throws SQLException {
-                            final String dateTimeZoneString = rs.getString(i);
-                            return dateTimeZoneString == null ? null : DateTimeZone.forID(dateTimeZoneString);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(String.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, String>() {
-
-                        @Override
-                        public String apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getString(i);
-                        }
-                    };
-                } else if (propertyType.isAssignableFrom(UUID.class)) {
-                    propertyMapper = new PropertyMapper<ResultSet, UUID>() {
-
-                        @Override
-                        public UUID apply(final ResultSet rs, final int i) throws SQLException {
-                            final String uuidString = rs.getString(i);
-                            return uuidString == null ? null : UUID.fromString(uuidString);
-                        }
-                    };
-                } else if (propertyType.isEnum()) {
-                    propertyMapper = new PropertyMapper<ResultSet, Enum>() {
-
-                        @Override
-                        public Enum apply(final ResultSet rs, final int i) throws SQLException {
-                            final String enumString = rs.getString(i);
-                            return enumString == null ? null : Enum.valueOf((Class<Enum>) propertyType, enumString);
-                        }
-                    };
-                } else if (propertyType == byte[].class) {
-                    propertyMapper = new PropertyMapper<ResultSet, byte[]>() {
-
-                        @Override
-                        public byte[] apply(final ResultSet rs, final int i) throws SQLException {
-                            return rs.getBytes(i);
-                        }
-                    };
-                } else {
-                    propertyMapper = new PropertyMapper<ResultSet, Time>() {
-
-                        @Override
-                        public Time apply(final ResultSet rs, final int i) throws SQLException {
-                            return (Time) rs.getObject(i);
-                        }
-                    };
-                }
+                final PropertyMapper<ResultSet, ?> propertyMapper = getPropertyMapper(descriptor);
                 propertiesMappers.put(key, propertyMapper);
             }
         } catch (final IntrospectionException e) {
@@ -221,12 +68,93 @@ public class LowerToCamelBeanMapper<T> implements ResultSetMapper<T> {
         }
     }
 
-    private static Field getField(final Class clazz, final String fieldName) throws NoSuchFieldException {
+    private static PropertyMapper<ResultSet, ?> getPropertyMapper(final PropertyDescriptor descriptor) {
+        final PropertyMapper<ResultSet, ?> propertyMapper;
+        final Class<?> propertyType = descriptor.getPropertyType();
+
+        if (propertyType.isAssignableFrom(Boolean.class) || propertyType.isAssignableFrom(boolean.class)) {
+            propertyMapper = ResultSet::getBoolean;
+
+        } else if (propertyType.isAssignableFrom(Byte.class) || propertyType.isAssignableFrom(byte.class)) {
+            propertyMapper = ResultSet::getByte;
+
+        } else if (propertyType.isAssignableFrom(Short.class) || propertyType.isAssignableFrom(short.class)) {
+            propertyMapper = ResultSet::getShort;
+
+        } else if (propertyType.isAssignableFrom(Integer.class) || propertyType.isAssignableFrom(int.class)) {
+            propertyMapper = ResultSet::getInt;
+
+        } else if (propertyType.isAssignableFrom(Long.class) || propertyType.isAssignableFrom(long.class)) {
+            propertyMapper = ResultSet::getLong;
+
+        } else if (propertyType.isAssignableFrom(Float.class) || propertyType.isAssignableFrom(float.class)) {
+            propertyMapper = ResultSet::getFloat;
+
+        } else if (propertyType.isAssignableFrom(Double.class) || propertyType.isAssignableFrom(double.class)) {
+            propertyMapper = ResultSet::getDouble;
+
+        } else if (propertyType.isAssignableFrom(BigDecimal.class)) {
+            propertyMapper = ResultSet::getBigDecimal;
+
+        } else if (propertyType.isAssignableFrom(DateTime.class)) {
+            propertyMapper = (rs, i) -> {
+                final Timestamp timestamp = rs.getTimestamp(i);
+                return timestamp == null ? null : new DateTime(timestamp).toDateTime(DateTimeZone.UTC);
+            };
+
+        } else if (propertyType.isAssignableFrom(Time.class)) {
+            propertyMapper = ResultSet::getTime;
+
+        } else if (propertyType.isAssignableFrom(LocalDate.class)) {
+            propertyMapper = (rs, i) -> {
+                // We store the LocalDate into a mysql 'date' as a string
+                // (See https://github.com/killbill/killbill-commons/blob/master/jdbi/src/main/java/org/killbill/commons/jdbi/argument/LocalDateArgumentFactory.java)
+                // So we also read it as a String which avoids any kind of transformation
+                //
+                // Note that we used previously the getDate(index, Calendar) method, but this is not thread safe as we discovered
+                // unless maybe -- untested --we pass a new instance of a Calendar each time
+                //
+                final String dateString = rs.getString(i);
+                return dateString == null ? null : new LocalDate(dateString, DateTimeZone.UTC);
+            };
+
+        } else if (propertyType.isAssignableFrom(DateTimeZone.class)) {
+            propertyMapper = (rs, i) -> {
+                final String dateTimeZoneString = rs.getString(i);
+                return dateTimeZoneString == null ? null : DateTimeZone.forID(dateTimeZoneString);
+            };
+
+        } else if (propertyType.isAssignableFrom(String.class)) {
+            propertyMapper = ResultSet::getString;
+
+        } else if (propertyType.isAssignableFrom(UUID.class)) {
+            propertyMapper = (rs, i) -> {
+                final String uuidString = rs.getString(i);
+                return uuidString == null ? null : UUID.fromString(uuidString);
+            };
+
+        } else if (propertyType.isEnum()) {
+            propertyMapper = (rs, i) -> {
+                final String enumString = rs.getString(i);
+                return enumString == null ? null : Enum.valueOf((Class<Enum>) propertyType, enumString);
+            };
+
+        } else if (propertyType == byte[].class) {
+            propertyMapper = ResultSet::getBytes;
+
+        } else {
+            propertyMapper = (rs, i) -> (Time) rs.getObject(i);
+        }
+
+        return propertyMapper;
+    }
+
+    private static Field getField(final Class<?> clazz, final String fieldName) throws NoSuchFieldException {
         try {
             return clazz.getDeclaredField(fieldName);
         } catch (final NoSuchFieldException e) {
             // Go up in the hierarchy
-            final Class superClass = clazz.getSuperclass();
+            final Class<?> superClass = clazz.getSuperclass();
             if (superClass == null) {
                 throw e;
             } else {
@@ -235,16 +163,13 @@ public class LowerToCamelBeanMapper<T> implements ResultSetMapper<T> {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    @SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION", justification = "Historic, unclear where NPE could come from")
+    @SuppressWarnings("rawtypes")
     public T map(final int row, final ResultSet rs, final StatementContext ctx) throws SQLException {
         final T bean;
         try {
-            bean = type.newInstance();
+            bean = type.getDeclaredConstructor().newInstance();
         } catch (final Exception e) {
-            throw new IllegalArgumentException(String.format("A bean, %s, was mapped " +
-                                                             "which was not instantiable", type.getName()),
-                                               e);
+            throw new IllegalArgumentException(String.format("A bean, %s, was mapped which was not instantiable", type.getName()), e);
         }
 
         final Class beanClass = bean.getClass();
@@ -253,7 +178,7 @@ public class LowerToCamelBeanMapper<T> implements ResultSetMapper<T> {
         for (int i = 1; i <= metadata.getColumnCount(); ++i) {
             final String name = metadata.getColumnLabel(i).toLowerCase();
 
-            final PropertyMapper propertyMapper = propertiesMappers.get(name);
+            final PropertyMapper<ResultSet, ?> propertyMapper = propertiesMappers.get(name);
             if (propertyMapper != null) {
                 Object value = propertyMapper.apply(rs, i);
 
@@ -278,20 +203,13 @@ public class LowerToCamelBeanMapper<T> implements ResultSetMapper<T> {
                         field.set(bean, value);
                     }
                 } catch (final IllegalArgumentException e) {
-                    throw new IllegalArgumentException(String.format("Unable to set field for " +
-                                                                     "property: name=%s, value=%s", name, value), e);
+                    throw new IllegalArgumentException(String.format("Unable to set field for property: name=%s, value=%s", name, value), e);
                 } catch (final NoSuchFieldException e) {
-                    throw new IllegalArgumentException(String.format("Unable to find field for " +
-                                                                     "property, %s", name), e);
+                    throw new IllegalArgumentException(String.format("Unable to find field for property, %s", name), e);
                 } catch (final IllegalAccessException e) {
-                    throw new IllegalArgumentException(String.format("Unable to access setter for " +
-                                                                     "property, %s", name), e);
+                    throw new IllegalArgumentException(String.format("Unable to access setter for property, %s", name), e);
                 } catch (final InvocationTargetException e) {
-                    throw new IllegalArgumentException(String.format("Invocation target exception trying to " +
-                                                                     "invoker setter for the %s property", name), e);
-                } catch (final NullPointerException e) {
-                    throw new IllegalArgumentException(String.format("No appropriate method to " +
-                                                                     "write value %s ", value), e);
+                    throw new IllegalArgumentException(String.format("Invocation target exception trying to invoker setter for the %s property", name), e);
                 }
             }
         }

--- a/jdbi/src/main/java/org/skife/jdbi/v2/BeanMapper.java
+++ b/jdbi/src/main/java/org/skife/jdbi/v2/BeanMapper.java
@@ -19,6 +19,7 @@
  */
 package org.skife.jdbi.v2;
 
+import org.killbill.commons.utils.annotation.VisibleForTesting;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.beans.BeanInfo;
@@ -26,6 +27,7 @@ import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -36,128 +38,116 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
  * A result set mapper which maps the fields in a statement into a JavaBean. This uses
- * the JDK's built in bean mapping facilities, so it does not support nested properties.
+ * the JDK's built-in bean mapping facilities, so it does not support nested properties.
  */
-public class BeanMapper<T> implements ResultSetMapper<T>
-{
+public class BeanMapper<T> implements ResultSetMapper<T> {
     private final Class<T> type;
-    private final Map<String, PropertyDescriptor> properties = new HashMap<String, PropertyDescriptor>();
+    private final Map<String, PropertyDescriptor> properties = new HashMap<>();
 
-    public BeanMapper(Class<T> type)
-    {
+    public BeanMapper(final Class<T> type) {
         this.type = type;
         try {
-            BeanInfo info = Introspector.getBeanInfo(type);
+            final BeanInfo info = Introspector.getBeanInfo(type);
 
-            for (PropertyDescriptor descriptor : info.getPropertyDescriptors()) {
+            for (final PropertyDescriptor descriptor : info.getPropertyDescriptors()) {
                 properties.put(descriptor.getName().toLowerCase(), descriptor);
             }
         }
-        catch (IntrospectionException e) {
+        catch (final IntrospectionException e) {
             throw new IllegalArgumentException(e);
         }
     }
 
     @Override
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION", justification = "Historic, unclear where NPE could come from")
-    public T map(int row, ResultSet rs, StatementContext ctx)
-        throws SQLException
-    {
-        T bean;
+    @SuppressWarnings({"rawtypes"})
+    public T map(final int row, final ResultSet rs, final StatementContext ctx) throws SQLException {
+        final T bean;
         try {
-            bean = type.newInstance();
-        }
-        catch (Exception e) {
-            throw new IllegalArgumentException(String.format("A bean, %s, was mapped " +
-                                                             "which was not instantiable", type.getName()), e);
+            bean = type.getDeclaredConstructor().newInstance();
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(String.format("A bean, %s, was mapped which was not instantiable", type.getName()), e);
         }
 
-        ResultSetMetaData metadata = rs.getMetaData();
+        final ResultSetMetaData metadata = rs.getMetaData();
 
         for (int i = 1; i <= metadata.getColumnCount(); ++i) {
-            String name = metadata.getColumnLabel(i).toLowerCase();
-
-            PropertyDescriptor descriptor = properties.get(name);
+            final String name = metadata.getColumnLabel(i).toLowerCase();
+            final PropertyDescriptor descriptor = properties.get(name);
 
             if (descriptor != null) {
-                Class type = descriptor.getPropertyType();
-
-                Object value;
-
-                if (type.isAssignableFrom(Boolean.class) || type.isAssignableFrom(boolean.class)) {
-                    value = rs.getBoolean(i);
+                final Class type = descriptor.getPropertyType();
+                final Object value = getValueFromResultSet(rs, type, i);
+                final Method method = descriptor.getWriteMethod();
+                if (method == null) {
+                    throw new IllegalArgumentException(String.format("No appropriate method to write property %s", name));
                 }
-                else if (type.isAssignableFrom(Byte.class) || type.isAssignableFrom(byte.class)) {
-                    value = rs.getByte(i);
-                }
-                else if (type.isAssignableFrom(Short.class) || type.isAssignableFrom(short.class)) {
-                    value = rs.getShort(i);
-                }
-                else if (type.isAssignableFrom(Integer.class) || type.isAssignableFrom(int.class)) {
-                    value = rs.getInt(i);
-                }
-                else if (type.isAssignableFrom(Long.class) || type.isAssignableFrom(long.class)) {
-                    value = rs.getLong(i);
-                }
-                else if (type.isAssignableFrom(Float.class) || type.isAssignableFrom(float.class)) {
-                    value = rs.getFloat(i);
-                }
-                else if (type.isAssignableFrom(Double.class) || type.isAssignableFrom(double.class)) {
-                    value = rs.getDouble(i);
-                }
-                else if (type.isAssignableFrom(BigDecimal.class)) {
-                    value = rs.getBigDecimal(i);
-                }
-                else if (type.isAssignableFrom(Timestamp.class)) {
-                    value = rs.getTimestamp(i);
-                }
-                else if (type.isAssignableFrom(Time.class)) {
-                    value = rs.getTime(i);
-                }
-                else if (type.isAssignableFrom(Date.class)) {
-                    value = rs.getDate(i);
-                }
-                else if (type.isAssignableFrom(String.class)) {
-                    value = rs.getString(i);
-                }
-                else if (type.isEnum()) {
-                    String str = rs.getString(i);
-                    value = str != null ? Enum.valueOf(type, str) : null;
-                }
-                else {
-                    value = rs.getObject(i);
-                }
-
-                if (rs.wasNull() && !type.isPrimitive()) {
-                    value = null;
-                }
-
-                try
-                {
+                try {
                     descriptor.getWriteMethod().invoke(bean, value);
                 }
-                catch (IllegalAccessException e) {
-                    throw new IllegalArgumentException(String.format("Unable to access setter for " +
-                                                                     "property, %s", name), e);
-                }
-                catch (InvocationTargetException e) {
-                    throw new IllegalArgumentException(String.format("Invocation target exception trying to " +
-                                                                     "invoker setter for the %s property", name), e);
-                }
-                catch (NullPointerException e) {
-                    throw new IllegalArgumentException(String.format("No appropriate method to " +
-                                                                     "write property %s", name), e);
+                catch (final IllegalAccessException e) {
+                    throw new IllegalArgumentException(String.format("Unable to access setter for property, %s", name), e);
+                } catch (final InvocationTargetException e) {
+                    throw new IllegalArgumentException(String.format("Invocation target exception trying to invoker setter for the %s property", name), e);
                 }
 
             }
         }
 
         return bean;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @VisibleForTesting
+    Object getValueFromResultSet(final ResultSet rs, final Class type, final int columnIndex) throws SQLException {
+        if (rs.wasNull() && !type.isPrimitive()) {
+            return null;
+        }
+
+        if (type.isAssignableFrom(Boolean.class) || type.isAssignableFrom(boolean.class)) {
+            return rs.getBoolean(columnIndex);
+        }
+        else if (type.isAssignableFrom(Byte.class) || type.isAssignableFrom(byte.class)) {
+            return rs.getByte(columnIndex);
+        }
+        else if (type.isAssignableFrom(Short.class) || type.isAssignableFrom(short.class)) {
+            return rs.getShort(columnIndex);
+        }
+        else if (type.isAssignableFrom(Integer.class) || type.isAssignableFrom(int.class)) {
+            return rs.getInt(columnIndex);
+        }
+        else if (type.isAssignableFrom(Long.class) || type.isAssignableFrom(long.class)) {
+            return rs.getLong(columnIndex);
+        }
+        else if (type.isAssignableFrom(Float.class) || type.isAssignableFrom(float.class)) {
+            return rs.getFloat(columnIndex);
+        }
+        else if (type.isAssignableFrom(Double.class) || type.isAssignableFrom(double.class)) {
+            return rs.getDouble(columnIndex);
+        }
+        else if (type.isAssignableFrom(BigDecimal.class)) {
+            return rs.getBigDecimal(columnIndex);
+        }
+        else if (type.isAssignableFrom(Timestamp.class)) {
+            return rs.getTimestamp(columnIndex);
+        }
+        else if (type.isAssignableFrom(Time.class)) {
+            return rs.getTime(columnIndex);
+        }
+        else if (type.isAssignableFrom(Date.class)) {
+            return rs.getDate(columnIndex);
+        }
+        else if (type.isAssignableFrom(String.class)) {
+            return rs.getString(columnIndex);
+        }
+        else if (type.isEnum()) {
+            final String str = rs.getString(columnIndex);
+            return str != null ? Enum.valueOf(type, str) : null;
+        }
+        else {
+            return rs.getObject(columnIndex);
+        }
     }
 }
 

--- a/jdbi/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
+++ b/jdbi/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
@@ -46,7 +46,6 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import com.fasterxml.classmate.members.ResolvedMethod;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@SuppressFBWarnings("IT_NO_SUCH_ELEMENT")
 class BatchHandler extends CustomizingStatementHandler
 {
     private final String  sql;
@@ -172,6 +171,7 @@ class BatchHandler extends CustomizingStatementHandler
                                    return true;
                                }
 
+                               @SuppressFBWarnings("IT_NO_SUCH_ELEMENT")
                                @Override
                                public Object next() {
                                    // This is the table name for instance (repeated during iteration)

--- a/jdbi/src/test/java/org/killbill/commons/jdbi/mapper/TestBeanMapper.java
+++ b/jdbi/src/test/java/org/killbill/commons/jdbi/mapper/TestBeanMapper.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.jdbi.mapper;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.BeanMapper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestBeanMapper {
+
+    private BeanMapper<Person> newBeanMapper() {
+        final BeanMapper<Person> toSpy = new BeanMapper<>(Person.class);
+        return Mockito.spy(toSpy);
+    }
+
+    private ResultSet createResultSet() throws SQLException {
+        final ResultSetMetaData rsmd = Mockito.mock(ResultSetMetaData.class);
+        Mockito.when(rsmd.getColumnCount()).thenReturn(3);
+        Mockito.when(rsmd.getColumnLabel(1)).thenReturn("name");
+        Mockito.when(rsmd.getColumnLabel(2)).thenReturn("age");
+        Mockito.when(rsmd.getColumnLabel(3)).thenReturn("address"); // mocking result from db. Person doesn't have address attribute
+
+        final ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.when(rs.getMetaData()).thenReturn(rsmd);
+        Mockito.when(rs.getString(1)).thenReturn("some name");
+        Mockito.when(rs.getInt(2)).thenReturn(30);
+        Mockito.when(rs.getString(3)).thenReturn("some address"); // mocking db result
+
+        return rs;
+    }
+
+    @Test(groups = "fast")
+    public void testMap() throws SQLException {
+        final BeanMapper<Person> spied = newBeanMapper();
+        final ResultSet rs = createResultSet();
+
+        final Person mapped = spied.map(0, rs, null);
+        Assert.assertEquals(mapped.getName(), "some name");
+        Assert.assertEquals(mapped.getAge(), 30);
+    }
+
+
+    public static class Person {
+
+        private String name;
+        private int age;
+
+        public void setSomething() {}
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(final int age) {
+            this.age = age;
+        }
+    }
+}


### PR DESCRIPTION
Related issue: https://github.com/killbill/killbill-commons/issues/113

- I removed this line and [comment](https://github.com/killbill/killbill-commons/compare/work-for-release-0.23.x...xsalefter:oss-113-spotbugs-jdbi?expand=1#diff-d82ba7b2bcee63ab97248c98f5337db46f74aef333898db70e415157786abac3L119): 
  ```java
  // Ensure we don't store an identity map entry which has a hard reference
  // to the key (through the value) by copying the value, avoids potential memory leak.
  found.put(cache_key, name == cache_key ? new String(name) : name);
  ```
  I'm not sure that `new String(name)` is necessary, but then again, I never experiencing any ".... identity map entry which has a hard reference that causing memory leak", so any thought are welcome.

- `LowerToCamelBeanMapper` get refactored, and verify against `TestLowerToCamelBeanMapper`.

- `BeanMapper` get refactored, add new test `TestBeanMapper`.
