### PR TITLE
Commons 113 spotbugs in locker and queue

### DIFF
--- a/locker/pom.xml
+++ b/locker/pom.xml
@@ -32,10 +32,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing-mysql-server</artifactId>
             <!-- Technically, test-runtime -->

--- a/locker/spotbugs-exclude.xml
+++ b/locker/spotbugs-exclude.xml
@@ -15,7 +15,22 @@
   ~ under the License.
   -->
 
-<FindBugsFilter>
-    <!-- https://github.com/spotbugs/spotbugs-maven-plugin/issues/92 -->
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- justification: Nothing we can do about this -->
+    <Match>
+        <Field type="javax.sql.DataSource" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- justification: Nothing we can do about this -->
+    <Match>
+        <Field type="java.sql.Connection" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
 </FindBugsFilter>

--- a/locker/src/main/java/org/killbill/commons/locker/GlobalLockBase.java
+++ b/locker/src/main/java/org/killbill/commons/locker/GlobalLockBase.java
@@ -28,8 +28,6 @@ import org.killbill.commons.profiling.ProfilingFeature.ProfilingFeatureType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class GlobalLockBase implements GlobalLock {
 
 
@@ -42,13 +40,12 @@ public class GlobalLockBase implements GlobalLock {
     private final ResetReentrantLockCallback resetCallback;
     private final Profiling<Void, RuntimeException> prof;
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public GlobalLockBase(final Connection connection, final String lockName, final GlobalLockDao lockDao, final ResetReentrantLockCallback resetCallback) {
         this.lockDao = lockDao;
         this.connection = connection;
         this.lockName = lockName;
         this.resetCallback = resetCallback;
-        this.prof = new Profiling<Void, RuntimeException>();
+        this.prof = new Profiling<>();
     }
 
     @Override

--- a/locker/src/main/java/org/killbill/commons/locker/GlobalLockerBaseWithDao.java
+++ b/locker/src/main/java/org/killbill/commons/locker/GlobalLockerBaseWithDao.java
@@ -28,9 +28,6 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP2")
 public abstract class GlobalLockerBaseWithDao extends GlobalLockerBase {
 
     private static final Logger logger = LoggerFactory.getLogger(GlobalLockerBaseWithDao.class);

--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -48,10 +48,6 @@
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/queue/spotbugs-exclude.xml
+++ b/queue/spotbugs-exclude.xml
@@ -14,14 +14,94 @@
   ~ License for the specific language governing permissions and limitations
   ~ under the License.
   -->
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
 
-<FindBugsFilter>
+    <!-- Most Joda time classes are immutable -->
     <Match>
-        <!-- Legacy code -->
-        <Bug pattern="EI_EXPOSE_REP"/>
+        <Field type="org.joda.time.DateTime" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
     </Match>
+
+    <!-- justification: DBBackedQueue instance supposed to be injected -->
     <Match>
-        <!-- Legacy code -->
-        <Bug pattern="EI_EXPOSE_REP2"/>
+        <Field type="org.killbill.queue.DBBackedQueue" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
     </Match>
+
+    <!-- justification: DBI instance supposed to be injected -->
+    <Match>
+        <Field type="org.skife.jdbi.v2.DBI" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- justification: NotificationQueueService supposed to be injected -->
+    <Match>
+        <Field type="org.killbill.notificationq.api.NotificationQueueService" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- justification: managed QueueSqlDao instance expected by its clients -->
+    <Match>
+        <Class name="org.killbill.queue.DBBackedQueue" />
+        <Method name="getSqlDao" />
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+
+    <!-- justification: List already copied in constructor, and this class have no further modification to the list -->
+    <Match>
+        <Class name="org.killbill.queue.DBBackedQueue$ReadyEntriesWithMetrics" />
+        <Method name="getEntries" />
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+
+    <!-- justification: Pretty safe - all clients use this by creating BlockingQueue implementation constructor directly. -->
+    <Match>
+        <Class name="org.killbill.queue.dispatching.Dispatcher" />
+        <Field type="java.util.concurrent.BlockingQueue" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- justification: the entry parameter is generic -->
+    <Match>
+        <Class name="org.killbill.queue.dispatching.Dispatcher$CallableQueueHandler" />
+        <Method name="&lt;init&gt;" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- justification: in this case, we don't really cares the output -->
+    <Match>
+        <Class name="org.killbill.queue.dispatching.Dispatcher" />
+        <Method name="dispatch" />
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
+    </Match>
+
+    <!-- justification: No other viable options ? -->
+    <Match>
+        <Class name="org.killbill.notificationq.NotificationQueueDispatcher" />
+        <Bug pattern="VO_VOLATILE_INCREMENT" />
+    </Match>
+
+    <!-- justification: Because this class immutable: https://stackoverflow.com/a/3909846/554958 -->
+    <Match>
+        <Field type="com.fasterxml.jackson.databind.ObjectReader" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- justification: Because this class immutable: https://stackoverflow.com/a/3909846/554958 -->
+    <Match>
+        <Field type="com.fasterxml.jackson.databind.ObjectWriter" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- justification: QueueObjectMapper is ObjectMapper factory for this module -->
+    <Match>
+        <Class name="org.killbill.queue.QueueObjectMapper" />
+        <Method name="get" />
+        <Bug pattern="MS_EXPOSE_REP" />
+    </Match>
+
 </FindBugsFilter>

--- a/queue/src/main/java/org/killbill/bus/dispatching/BusCallableCallback.java
+++ b/queue/src/main/java/org/killbill/bus/dispatching/BusCallableCallback.java
@@ -33,7 +33,7 @@ public class BusCallableCallback extends CallableCallbackBase<BusEvent, BusEvent
     private final DefaultPersistentBus parent;
 
     public BusCallableCallback(final DefaultPersistentBus parent) {
-        super(parent.getDao(), parent.getClock(), parent.getConfig(), parent.getObjectMapper());
+        super(parent.getDao(), parent.getClock(), parent.getConfig(), parent.getObjectReader());
         this.parent = parent;
     }
 

--- a/queue/src/main/java/org/killbill/notificationq/NotificationQueueDispatcher.java
+++ b/queue/src/main/java/org/killbill/notificationq/NotificationQueueDispatcher.java
@@ -53,9 +53,6 @@ import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("VO_VOLATILE_INCREMENT")
 public class NotificationQueueDispatcher extends DefaultQueueLifecycle {
 
     protected static final Logger log = LoggerFactory.getLogger(NotificationQueueDispatcher.class);

--- a/queue/src/main/java/org/killbill/notificationq/dispatching/NotificationCallableCallback.java
+++ b/queue/src/main/java/org/killbill/notificationq/dispatching/NotificationCallableCallback.java
@@ -37,7 +37,7 @@ public class NotificationCallableCallback extends CallableCallbackBase<Notificat
     private final NotificationQueueDispatcher parent;
 
     public NotificationCallableCallback(final NotificationQueueDispatcher parent) {
-        super(parent.getDao(), parent.getClock(), parent.getConfig(), parent.getObjectMapper());
+        super(parent.getDao(), parent.getClock(), parent.getConfig(), parent.getObjectReader());
         this.parent = parent;
     }
 

--- a/queue/src/main/java/org/killbill/queue/DBBackedQueue.java
+++ b/queue/src/main/java/org/killbill/queue/DBBackedQueue.java
@@ -120,7 +120,7 @@ public abstract class DBBackedQueue<T extends EventEntryModelDao> {
         private final long time;
 
         public ReadyEntriesWithMetrics(final List<T> entries, final long time) {
-            this.entries = entries;
+            this.entries = new ArrayList<>(entries);
             this.time = time;
         }
 

--- a/queue/src/main/java/org/killbill/queue/DefaultQueueLifecycle.java
+++ b/queue/src/main/java/org/killbill/queue/DefaultQueueLifecycle.java
@@ -38,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 
 public abstract class DefaultQueueLifecycle implements QueueLifecycle {
 
@@ -53,7 +55,8 @@ public abstract class DefaultQueueLifecycle implements QueueLifecycle {
     private static final int MAX_COMPLETED_ENTRIES = 15;
 
     protected final String svcQName;
-    protected final ObjectMapper objectMapper;
+    protected final ObjectReader objectReader;
+    protected final ObjectWriter objectWriter;
     protected final PersistentQueueConfig config;
     private final LinkedBlockingQueue<EventEntryModelDao> completedOrFailedEvents;
     private final LinkedBlockingQueue<EventEntryModelDao> retriedEvents;
@@ -88,7 +91,8 @@ public abstract class DefaultQueueLifecycle implements QueueLifecycle {
         this.config = config;
         this.isDispatchingEvents = false;
         this.isCompletingEvents = false;
-        this.objectMapper = objectMapper;
+        this.objectReader = objectMapper.reader();
+        this.objectWriter = objectMapper.writer();
         this.completedOrFailedEvents = new LinkedBlockingQueue<>();
         this.retriedEvents = new LinkedBlockingQueue<>();
         this.isStickyEvent = config.getPersistentQueueMode() == PersistentQueueConfig.PersistentQueueMode.STICKY_EVENTS;
@@ -176,8 +180,12 @@ public abstract class DefaultQueueLifecycle implements QueueLifecycle {
 
     public abstract void doProcessRetriedEvents(final Iterable<? extends EventEntryModelDao> retried);
 
-    public ObjectMapper getObjectMapper() {
-        return objectMapper;
+    public ObjectReader getObjectReader() {
+        return objectReader;
+    }
+
+    public ObjectWriter getObjectWriter() {
+        return objectWriter;
     }
 
     public static class DispatchResultMetrics {

--- a/queue/src/main/java/org/killbill/queue/QueueObjectMapper.java
+++ b/queue/src/main/java/org/killbill/queue/QueueObjectMapper.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class QueueObjectMapper {
 
@@ -35,7 +34,6 @@ public class QueueObjectMapper {
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
-    @SuppressFBWarnings("MS_EXPOSE_REP")
     public static ObjectMapper get() {
         return objectMapper;
     }

--- a/queue/src/main/java/org/killbill/queue/dispatching/Dispatcher.java
+++ b/queue/src/main/java/org/killbill/queue/dispatching/Dispatcher.java
@@ -40,8 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class Dispatcher<E extends QueueEvent, M extends EventEntryModelDao> {
 
     private static final Logger log = LoggerFactory.getLogger(Dispatcher.class);
@@ -107,7 +105,6 @@ public class Dispatcher<E extends QueueEvent, M extends EventEntryModelDao> {
         }
     }
 
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     public void dispatch(final M modelDao) {
         log.debug("Dispatching entry {}", modelDao);
         final CallableQueueHandler<E, M> entry = new CallableQueueHandler<E, M>(modelDao, handlerCallback, parentLifeCycle, clock, maxFailureRetries);

--- a/queue/src/main/java/org/killbill/queue/dispatching/EventEntryDeserializer.java
+++ b/queue/src/main/java/org/killbill/queue/dispatching/EventEntryDeserializer.java
@@ -33,7 +33,7 @@ public final class EventEntryDeserializer {
             final Class<?> claz = Class.forName(modelDao.getClassName());
             return (E) objectReader.readValue(modelDao.getEventJson(), claz);
         } catch (final Exception e) {
-            log.error(String.format("Failed to deserialize json object %s for class %s", modelDao.getEventJson(), modelDao.getClassName()), e);
+            log.error("Failed to deserialize json object {} for class {}", modelDao.getEventJson(), modelDao.getClassName(), e);
             return null;
         }
     }

--- a/queue/src/main/java/org/killbill/queue/dispatching/EventEntryDeserializer.java
+++ b/queue/src/main/java/org/killbill/queue/dispatching/EventEntryDeserializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.queue.dispatching;
+
+import org.killbill.queue.api.QueueEvent;
+import org.killbill.queue.dao.EventEntryModelDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectReader;
+
+public final class EventEntryDeserializer {
+
+    private static final Logger log = LoggerFactory.getLogger(EventEntryDeserializer.class);
+
+    public static <E extends QueueEvent, M extends EventEntryModelDao> E deserialize(final M modelDao, final ObjectReader objectReader) {
+        try {
+            final Class<?> claz = Class.forName(modelDao.getClassName());
+            return (E) objectReader.readValue(modelDao.getEventJson(), claz);
+        } catch (final Exception e) {
+            log.error(String.format("Failed to deserialize json object %s for class %s", modelDao.getEventJson(), modelDao.getClassName()), e);
+            return null;
+        }
+    }
+}

--- a/queue/src/test/java/org/killbill/notificationq/MockNotificationQueue.java
+++ b/queue/src/test/java/org/killbill/notificationq/MockNotificationQueue.java
@@ -38,7 +38,7 @@ import org.killbill.notificationq.api.NotificationQueue;
 import org.killbill.notificationq.api.NotificationQueueService.NotificationQueueHandler;
 import org.killbill.notificationq.dao.NotificationEventModelDao;
 import org.killbill.queue.api.PersistentQueueEntryLifecycleState;
-import org.killbill.queue.dispatching.CallableCallbackBase;
+import org.killbill.queue.dispatching.EventEntryDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,7 +174,7 @@ public class MockNotificationQueue implements NotificationQueue {
                 if (notification.getSearchKey1().equals(searchKey1) &&
                     type.getName().equals(notification.getClassName()) &&
                     notification.getEffectiveDate().isAfter(clock.getUTCNow())) {
-                    final T event = CallableCallbackBase.deserializeEvent(notification, objectMapper);
+                    final T event = EventEntryDeserializer.deserialize(notification, objectMapper.reader());
                     final NotificationEventWithMetadata<T> foo = new NotificationEventWithMetadata<T>(notification.getRecordId(), notification.getUserToken(), notification.getCreatedDate(), notification.getSearchKey1(), notification.getSearchKey2(), event,
                                                                                                       notification.getFutureUserToken(), notification.getEffectiveDate(), notification.getQueueName());
                     result.add(foo);

--- a/queue/src/test/java/org/killbill/notificationq/MockNotificationQueueService.java
+++ b/queue/src/test/java/org/killbill/notificationq/MockNotificationQueueService.java
@@ -33,7 +33,7 @@ import org.killbill.notificationq.api.NotificationQueue;
 import org.killbill.notificationq.api.NotificationQueueConfig;
 import org.killbill.notificationq.dao.NotificationEventModelDao;
 import org.killbill.queue.api.PersistentQueueEntryLifecycleState;
-import org.killbill.queue.dispatching.CallableCallbackBase;
+import org.killbill.queue.dispatching.EventEntryDeserializer;
 import org.skife.jdbi.v2.DBI;
 
 public class MockNotificationQueueService extends NotificationQueueServiceBase {
@@ -78,7 +78,7 @@ public class MockNotificationQueueService extends NotificationQueueServiceBase {
 
         final List<NotificationEventModelDao> readyNotifications = queue.getReadyNotifications();
         for (final NotificationEventModelDao cur : readyNotifications) {
-            final NotificationEvent key = CallableCallbackBase.deserializeEvent(cur, objectMapper);
+            final NotificationEvent key = EventEntryDeserializer.deserialize(cur, objectReader);
             queue.getHandler().handleReadyNotification(key, cur.getEffectiveDate(), cur.getFutureUserToken(), cur.getSearchKey1(), cur.getSearchKey2());
 
 


### PR DESCRIPTION
See: https://github.com/killbill/killbill-commons/issues/113. This PR affected locker and queue modules. 

Commit in Oct 8 may contains casual update. However, commit in Oct 11 probably need attention:
- These are the commits: https://github.com/killbill/killbill-commons/commit/d9c3565534d9ee13eac482890877fb8e32271b4e , https://github.com/killbill/killbill-commons/commit/4a667c04acf7afc4b7de552f7cf6e9bb612c30e9 , https://github.com/killbill/killbill-commons/commit/a32ba65646fb9176a6cd3511889deb222a425ee0 , https://github.com/killbill/killbill-commons/commit/f665f34da6e8c75f149c7e6e98198ad4a041830b .
- To wrap it up: we use `ObjectReader` + `ObjectWriter` (that obtained via `ObjectMapper`) instead of `ObjectMapper`. See more [here](https://stackoverflow.com/a/3909846/554958).
- Tested against `killbill/work-for-release-0.23.x`.