### PR TITLE
Commons 113 spotbugs in xmlloader and automaton

### DIFF
--- a/automaton/pom.xml
+++ b/automaton/pom.xml
@@ -32,10 +32,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/automaton/spotbugs-exclude.xml
+++ b/automaton/spotbugs-exclude.xml
@@ -15,13 +15,103 @@
   ~ under the License.
   -->
 
-<FindBugsFilter>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
     <Match>
-        <!-- Legacy code -->
-        <Bug pattern="EI_EXPOSE_REP"/>
+        <Class name="org.killbill.automaton.DefaultLinkStateMachine" />
+        <Or>
+            <!-- EI_EXPOSE_REP -->
+            <Method name="getFinalState" />
+            <Method name="getFinalStateMachine" />
+            <Method name="getInitialState" />
+            <Method name="getInitialStateMachine" />
+
+            <!-- EI_EXPOSE_REP2 -->
+            <Method name="setFinalState" />
+            <Method name="setFinalStateMachine" />
+            <Method name="setInitialState" />
+            <Method name="setInitialStateMachine" />
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
     </Match>
+
     <Match>
-        <!-- Legacy code -->
-        <Bug pattern="EI_EXPOSE_REP2"/>
+        <Class name="org.killbill.automaton.DefaultStateMachine" />
+        <Or>
+            <!-- EI_EXPOSE_REP -->
+            <Method name="getStateMachineConfig" />
+            <Method name="getStates" />
+            <Method name="getTransitions" />
+            <Method name="getOperations" />
+
+            <!-- EI_EXPOSE_REP2 -->
+            <Method name="initialize" />
+            <Method name="setStateMachineConfig" />
+            <Method name="setStates" />
+            <Method name="setTransitions" />
+            <Method name="setOperations" />
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
     </Match>
+
+    <Match>
+        <Class name="org.killbill.automaton.DefaultState" />
+        <Or>
+            <Method name="getStateMachine" />
+            <Method name="setStateMachine" />
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
+    <Match>
+        <Class name="org.killbill.automaton.DefaultOperation" />
+        <Or>
+            <Method name="getStateMachine" />
+            <Method name="setStateMachine" />
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
+    <Match>
+        <Class name="org.killbill.automaton.DefaultTransition" />
+        <Or>
+            <!-- EI_EXPOSE_REP -->
+            <Method name="getFinalState" />
+            <Method name="getInitialState" />
+            <Method name="getOperation" />
+            <Method name="getStateMachine" />
+
+            <!-- EI_EXPOSE_REP2 -->
+            <Method name="setFinalState" />
+            <Method name="setInitialState" />
+            <Method name="setOperation" />
+            <Method name="setStateMachine" />
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
+    <Match>
+        <Class name="org.killbill.automaton.dot.DefaultStateMachineConfigDOTGenerator" />
+        <Method name="getDot" />
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+
+    <Match>
+        <Class name="org.killbill.automaton.DefaultStateMachineConfig" />
+        <Or>
+            <!-- EI_EXPOSE_REP -->
+            <Method name="getStateMachines" />
+            <Method name="getLinkStateMachines" />
+
+            <!-- EI_EXPOSE_REP2 -->
+            <Method name="setStateMachines" />
+            <Method name="setLinkStateMachines" />
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
 </FindBugsFilter>

--- a/automaton/src/main/java/org/killbill/automaton/DefaultStateMachine.java
+++ b/automaton/src/main/java/org/killbill/automaton/DefaultStateMachine.java
@@ -36,9 +36,6 @@ import javax.xml.bind.annotation.XmlID;
 
 import org.killbill.xmlloader.ValidationErrors;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @XmlAccessorType(XmlAccessType.NONE)
 public class DefaultStateMachine extends StateMachineValidatingConfig<DefaultStateMachineConfig> implements StateMachine, Externalizable {
 

--- a/automaton/src/main/java/org/killbill/automaton/DefaultStateMachineConfig.java
+++ b/automaton/src/main/java/org/killbill/automaton/DefaultStateMachineConfig.java
@@ -35,9 +35,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.killbill.xmlloader.ValidationErrors;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @XmlRootElement(name = "stateMachineConfig")
 @XmlAccessorType(XmlAccessType.NONE)
 public class DefaultStateMachineConfig extends StateMachineValidatingConfig<DefaultStateMachineConfig> implements StateMachineConfig, Externalizable {

--- a/skeleton/spotbugs-exclude.xml
+++ b/skeleton/spotbugs-exclude.xml
@@ -43,6 +43,7 @@
             <Method name="configureRegularServletsRegex" />
             <Method name="configureResources" />
         </Or>
+        <Bug pattern="WMI_WRONG_MAP_ITERATOR" />
     </Match>
 
 </FindBugsFilter>

--- a/xmlloader/pom.xml
+++ b/xmlloader/pom.xml
@@ -27,11 +27,10 @@
     </parent>
     <artifactId>killbill-xmlloader</artifactId>
     <name>Kill Bill xml utils for loading jaxb xml object tree</name>
+    <properties>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
+    </properties>
     <dependencies>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>

--- a/xmlloader/spotbugs-exclude.xml
+++ b/xmlloader/spotbugs-exclude.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright 2020-2021 Equinix, Inc
+  ~ Copyright 2014-2021 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <Class name="org.killbill.xmlloader.ValidationException" />
+        <Method name="getErrors" />
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+
+</FindBugsFilter>

--- a/xmlloader/src/main/java/org/killbill/xmlloader/ValidationError.java
+++ b/xmlloader/src/main/java/org/killbill/xmlloader/ValidationError.java
@@ -21,9 +21,6 @@ package org.killbill.xmlloader;
 
 import org.slf4j.Logger;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class ValidationError {
 
     private final String description;

--- a/xmlloader/src/main/java/org/killbill/xmlloader/ValidationException.java
+++ b/xmlloader/src/main/java/org/killbill/xmlloader/ValidationException.java
@@ -21,9 +21,6 @@ package org.killbill.xmlloader;
 
 import java.io.PrintStream;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP")
 public class ValidationException extends Exception {
 
     private final ValidationErrors errors;


### PR DESCRIPTION
Some notes: 
- I don't think we need copy constructor for [jaxb classes](https://github.com/killbill/killbill-commons/commit/b23e678d9ccbce7a86ddd742a63d7e88304ad13e).
- I call `clone()` to getter/setter to array [based attributes](https://github.com/killbill/killbill-commons/commit/6551d89dbc8b0120e9668ba103fc3db337e11f2e).
- This is last PR for #113 in killbill-commons.