### PR TITLE
change jdbcConnectionPool.setMaxConnections() to 50

### DIFF
--- a/embeddeddb/h2/src/main/java/org/killbill/commons/embeddeddb/h2/H2EmbeddedDB.java
+++ b/embeddeddb/h2/src/main/java/org/killbill/commons/embeddeddb/h2/H2EmbeddedDB.java
@@ -120,8 +120,9 @@ public class H2EmbeddedDB extends EmbeddedDB {
             dataSource = createHikariDataSource();
         } else {
             final JdbcConnectionPool jdbcConnectionPool = JdbcConnectionPool.create(jdbcConnectionString, username, password);
-            // Default is 10, set it to 30 to match the default for org.killbill.dao.maxActive
-            jdbcConnectionPool.setMaxConnections(30);
+            // Default is 10, set it to 30 to match the default for org.killbill.dao.maxActive.
+            // set to 100 temporarily to temporarily solve CI problem: https://github.com/killbill/killbill/issues/1799
+            jdbcConnectionPool.setMaxConnections(100);
             dataSource = jdbcConnectionPool;
         }
     }


### PR DESCRIPTION
for CI debugging purpose. Better solution might be added by reverting this, once we get more context. Decided to set connection pool to 100 instead, although the branch name is "set to 50".