### PR TITLE
Update default queue mode to POLLING

### DIFF
--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -66,7 +66,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- Don't run JUnit tests -->
-                    <groups />
+                    <groups/>
                 </configuration>
             </plugin>
         </plugins>

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -26,5 +26,5 @@
     <properties>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
     </properties>
-    <dependencies />
+    <dependencies/>
 </project>

--- a/queue/src/main/java/org/killbill/bus/api/PersistentBusConfig.java
+++ b/queue/src/main/java/org/killbill/bus/api/PersistentBusConfig.java
@@ -59,7 +59,7 @@ public abstract class PersistentBusConfig implements PersistentQueueConfig {
 
     @Override
     @Config("org.killbill.persistent.bus.${instanceName}.queue.mode")
-    @Default("STICKY_EVENTS")
+    @Default("POLLING")
     @Description("How entries are put in the queue")
     public abstract PersistentQueueMode getPersistentQueueMode();
 

--- a/queue/src/main/java/org/killbill/notificationq/api/NotificationQueueConfig.java
+++ b/queue/src/main/java/org/killbill/notificationq/api/NotificationQueueConfig.java
@@ -61,7 +61,7 @@ public abstract class NotificationQueueConfig implements PersistentQueueConfig {
 
     @Override
     @Config("org.killbill.notificationq.${instanceName}.queue.mode")
-    @Default("STICKY_POLLING")
+    @Default("POLLING")
     @Description("How entries are put in the queue")
     public abstract PersistentQueueMode getPersistentQueueMode();
 


### PR DESCRIPTION
Updated default queue mode to `POLLING` as discussed [here](https://github.com/killbill/killbill-aviate-plugin/issues/40#issuecomment-2798801111). 

~~Edit: Moving to `DRAFT` as there are [ci failures](https://github.com/killbill/killbill-commons/actions/runs/14442833600).~~

Moving back to `IN_REVIEW` as there are no ci failures now. 