### PR TITLE
ConfigurationObjectFactory changes

### DIFF
--- a/config-magic/src/main/java/org/skife/config/AugmentedConfigurationObjectFactory.java
+++ b/config-magic/src/main/java/org/skife/config/AugmentedConfigurationObjectFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020-2025 Equinix, Inc
+ * Copyright 2014-2025 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.skife.config;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Augmented version of {@link ConfigurationObjectFactory} that collects resolved config properties
+ * at runtime and registers them in {@link RuntimeConfigRegistry}.
+ */
+public class AugmentedConfigurationObjectFactory extends ConfigurationObjectFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(AugmentedConfigurationObjectFactory.class);
+
+    public AugmentedConfigurationObjectFactory(final Properties props) {
+        super(new SimplePropertyConfigSource(props));
+    }
+
+    public AugmentedConfigurationObjectFactory(final ConfigSource configSource) {
+        super(configSource);
+    }
+
+    @Override
+    public <T> T build(final Class<T> configClass) {
+        final T instance = super.build(configClass);
+
+        collectConfigValues(configClass, instance);
+
+        return instance;
+    }
+
+    private <T> void collectConfigValues(final Class<T> configClass, final T instance) {
+        for (final Method method : configClass.getMethods()) {
+            final Config configAnnotation = method.getAnnotation(Config.class);
+            if (configAnnotation != null && method.getParameterCount() == 0) {
+                try {
+                    final Object value = method.invoke(instance);
+                    final String[] keys = configAnnotation.value();
+                    Arrays.stream(keys)
+                          .forEach(key -> RuntimeConfigRegistry.put(key, value));
+
+                } catch (final IllegalAccessException | InvocationTargetException e) {
+                    log.warn("Failed to resolve config method: {}", method.getName(), e);
+                }
+            } else if (configAnnotation != null) {
+                log.debug("Skipping config method {} due to parameters", method.getName());
+            }
+        }
+    }
+}

--- a/config-magic/src/main/java/org/skife/config/ConfigurationObjectFactory.java
+++ b/config-magic/src/main/java/org/skife/config/ConfigurationObjectFactory.java
@@ -40,7 +40,7 @@ import net.bytebuddy.implementation.InvocationHandlerAdapter;
 import net.bytebuddy.implementation.SuperMethodCall;
 import net.bytebuddy.matcher.ElementMatchers;
 
-public class ConfigurationObjectFactory {
+class ConfigurationObjectFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigurationObjectFactory.class);
 

--- a/config-magic/src/main/java/org/skife/config/RuntimeConfigRegistry.java
+++ b/config-magic/src/main/java/org/skife/config/RuntimeConfigRegistry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020-2025 Equinix, Inc
+ * Copyright 2014-2025 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.skife.config;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry to capture and expose runtime configuration values.
+ */
+public class RuntimeConfigRegistry {
+
+    private static final Map<String, String> RUNTIME_CONFIGS = new ConcurrentHashMap<>();
+
+    public static void put(final String key, final Object value) {
+        RUNTIME_CONFIGS.put(key, value == null ? "" : value.toString());
+    }
+
+    public static String get(final String key) {
+        return RUNTIME_CONFIGS.getOrDefault(key, "");
+    }
+
+    public static Map<String, String> getAll() {
+        return Collections.unmodifiableMap(RUNTIME_CONFIGS);
+    }
+}

--- a/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
+++ b/jdbi/src/test/java/org/killbill/commons/jdbi/guice/TestDataSourceProvider.java
@@ -51,7 +51,7 @@ import org.killbill.commons.embeddeddb.h2.H2EmbeddedDB;
 import org.killbill.commons.embeddeddb.mysql.KillBillMariaDbDataSource;
 import org.killbill.commons.jdbi.guice.DataSourceProvider.DatabaseType;
 import org.mariadb.jdbc.Configuration;
-import org.skife.config.ConfigurationObjectFactory;
+import org.skife.config.AugmentedConfigurationObjectFactory;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
@@ -195,7 +195,7 @@ public class TestDataSourceProvider {
     }
 
     DaoConfig buildDaoConfig(final Properties properties) {
-        return new ConfigurationObjectFactory(properties).build(DaoConfig.class);
+        return new AugmentedConfigurationObjectFactory(properties).build(DaoConfig.class);
     }
 
     private Properties defaultDaoConfigProperties(final DataSourceConnectionPoolingType poolingType, final DataSourceProvider.DatabaseType databaseType) {

--- a/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
+++ b/queue/src/main/java/org/killbill/bus/DefaultPersistentBus.java
@@ -66,7 +66,7 @@ import org.killbill.queue.dao.EventEntryModelDao;
 import org.killbill.queue.dispatching.BlockingRejectionExecutionHandler;
 import org.killbill.queue.dispatching.Dispatcher;
 import org.killbill.queue.dispatching.EventEntryDeserializer;
-import org.skife.config.ConfigurationObjectFactory;
+import org.skife.config.AugmentedConfigurationObjectFactory;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
@@ -151,7 +151,7 @@ public class DefaultPersistentBus extends DefaultQueueLifecycle implements Persi
     public DefaultPersistentBus(final DataSource dataSource, final Properties properties) {
         this(InTransaction.buildDDBI(dataSource),
              new DefaultClock(),
-             new ConfigurationObjectFactory(properties).buildWithReplacements(PersistentBusConfig.class, Map.of("instanceName", "main")),
+             new AugmentedConfigurationObjectFactory(properties).buildWithReplacements(PersistentBusConfig.class, Map.of("instanceName", "main")),
              new NoOpMetricRegistry(),
              new DatabaseTransactionNotificationApi());
     }

--- a/queue/src/main/java/org/killbill/notificationq/DefaultNotificationQueueService.java
+++ b/queue/src/main/java/org/killbill/notificationq/DefaultNotificationQueueService.java
@@ -33,7 +33,7 @@ import org.killbill.commons.metrics.impl.NoOpMetricRegistry;
 import org.killbill.notificationq.api.NotificationQueue;
 import org.killbill.notificationq.api.NotificationQueueConfig;
 import org.killbill.queue.InTransaction;
-import org.skife.config.ConfigurationObjectFactory;
+import org.skife.config.AugmentedConfigurationObjectFactory;
 import org.skife.config.SimplePropertyConfigSource;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.IDBI;
@@ -68,7 +68,7 @@ public class DefaultNotificationQueueService extends NotificationQueueServiceBas
     public DefaultNotificationQueueService(final DataSource dataSource, final Properties properties) {
         this(InTransaction.buildDDBI(dataSource),
              new DefaultClock(),
-             new ConfigurationObjectFactory(new SimplePropertyConfigSource(properties)).buildWithReplacements(NotificationQueueConfig.class, Map.of("instanceName", "main")),
+             new AugmentedConfigurationObjectFactory(new SimplePropertyConfigSource(properties)).buildWithReplacements(NotificationQueueConfig.class, Map.of("instanceName", "main")),
              new NoOpMetricRegistry());
     }
 

--- a/queue/src/test/java/org/killbill/TestSetup.java
+++ b/queue/src/test/java/org/killbill/TestSetup.java
@@ -39,8 +39,8 @@ import org.killbill.commons.utils.io.ByteStreams;
 import org.killbill.commons.utils.io.Resources;
 import org.killbill.notificationq.api.NotificationQueueConfig;
 import org.killbill.queue.InTransaction;
+import org.skife.config.AugmentedConfigurationObjectFactory;
 import org.skife.config.ConfigSource;
-import org.skife.config.ConfigurationObjectFactory;
 import org.skife.config.SimplePropertyConfigSource;
 import org.skife.jdbi.v2.DBI;
 import org.testng.annotations.AfterClass;
@@ -111,10 +111,10 @@ public class TestSetup {
         dbi.setTransactionHandler(new NotificationTransactionHandler(databaseTransactionNotificationApi));
 
         final ConfigSource configSource = new SimplePropertyConfigSource(System.getProperties());
-        persistentBusConfig = new ConfigurationObjectFactory(configSource).buildWithReplacements(
+        persistentBusConfig = new AugmentedConfigurationObjectFactory(configSource).buildWithReplacements(
                 PersistentBusConfig.class,
                 Map.of("instanceName", "main"));
-        notificationQueueConfig = new ConfigurationObjectFactory(configSource).buildWithReplacements(
+        notificationQueueConfig = new AugmentedConfigurationObjectFactory(configSource).buildWithReplacements(
                 NotificationQueueConfig.class,
                 Map.of("instanceName", "main"));
     }

--- a/queue/src/test/java/org/killbill/bus/TestLoadDefaultPersistentBus.java
+++ b/queue/src/test/java/org/killbill/bus/TestLoadDefaultPersistentBus.java
@@ -34,7 +34,7 @@ import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBusConfig;
 import org.killbill.commons.eventbus.AllowConcurrentEvents;
 import org.killbill.commons.eventbus.Subscribe;
-import org.skife.config.ConfigurationObjectFactory;
+import org.skife.config.AugmentedConfigurationObjectFactory;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.TransactionCallback;
 import org.skife.jdbi.v2.TransactionStatus;
@@ -69,7 +69,7 @@ public class TestLoadDefaultPersistentBus extends TestSetup {
         properties.setProperty("org.killbill.persistent.bus.main.sleep", "0");
         properties.setProperty("org.killbill.persistent.bus.main.sticky", "true");
         properties.setProperty("org.killbill.persistent.bus.main.useInflightQ", "true");
-        final PersistentBusConfig busConfig = new ConfigurationObjectFactory(properties).buildWithReplacements(PersistentBusConfig.class, Map.of("instanceName", "main"));
+        final PersistentBusConfig busConfig = new AugmentedConfigurationObjectFactory(properties).buildWithReplacements(PersistentBusConfig.class, Map.of("instanceName", "main"));
 
         eventBus = new DefaultPersistentBus(dbi, clock, busConfig, metricRegistry, databaseTransactionNotificationApi);
     }

--- a/skeleton/src/main/java/org/killbill/commons/skeleton/modules/ConfigModule.java
+++ b/skeleton/src/main/java/org/killbill/commons/skeleton/modules/ConfigModule.java
@@ -23,8 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import org.skife.config.AugmentedConfigurationObjectFactory;
 import org.skife.config.ConfigSource;
-import org.skife.config.ConfigurationObjectFactory;
 import org.skife.config.SimplePropertyConfigSource;
 
 import com.google.inject.AbstractModule;
@@ -63,7 +63,7 @@ public class ConfigModule extends AbstractModule {
     @Override
     protected void configure() {
         for (final Class config : configs) {
-            bind(config).toInstance(new ConfigurationObjectFactory(configSource).build(config));
+            bind(config).toInstance(new AugmentedConfigurationObjectFactory(configSource).build(config));
         }
     }
 }


### PR DESCRIPTION
* Made ConfigurationObjectFactory package private to limit external usage
* Enhanced AugmentedConfigurationObjectFactory to collect runtime configuration values and store them in RuntimeConfigRegistry.