### PR TITLE
Fix release failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           # Will be pushed as part of the release process, only if the release is successful
           git commit -m "pom.xml: update killbill-oss-parent to ${{ github.event.inputs.parent_version }}"
       - name: Configure settings.xml for release
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           server-id: central

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: temurin
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -80,7 +81,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         # It will still check the remote but hopefully not download much (0 B at 0 B/s). -o isn't safe because of MDEP-82 (see above).
         run: |
-          mvn ${MAVEN_FLAGS} release:clean release:prepare release:perform
+          mvn ${MAVEN_FLAGS} clean deploy -Psonatype-oss-release
       - name: Perform release
         if: github.event.inputs.perform_version != ''
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         # It will still check the remote but hopefully not download much (0 B at 0 B/s). -o isn't safe because of MDEP-82 (see above).
         run: |
-          mvn ${MAVEN_FLAGS} clean deploy -Psonatype-oss-release
+          mvn ${MAVEN_FLAGS} release:clean release:prepare release:perform
       - name: Perform release
         if: github.event.inputs.perform_version != ''
         env:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,5 +8,5 @@ jobs:
   snapshot:
     uses: killbill/gh-actions-shared/.github/workflows/snapshot.yml@main
     secrets:
-      OSSRH_USER: ${{ secrets.OSSRH_USER }}
-      OSSRH_PASS: ${{ secrets.OSSRH_PASS }}
+      OSSRH_USER: ${{ secrets.MAVEN_USERNAME }}
+      OSSRH_PASS: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,5 +8,5 @@ jobs:
   snapshot:
     uses: killbill/gh-actions-shared/.github/workflows/snapshot.yml@main
     secrets:
-      OSSRH_USER: ${{ secrets.MAVEN_USERNAME }}
-      OSSRH_PASS: ${{ secrets.MAVEN_PASSWORD }}
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>

--- a/automaton/pom.xml
+++ b/automaton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-automaton</artifactId>

--- a/automaton/pom.xml
+++ b/automaton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-automaton</artifactId>

--- a/automaton/pom.xml
+++ b/automaton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-automaton</artifactId>

--- a/automaton/pom.xml
+++ b/automaton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-automaton</artifactId>

--- a/automaton/pom.xml
+++ b/automaton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-automaton</artifactId>

--- a/automaton/pom.xml
+++ b/automaton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-automaton</artifactId>

--- a/clock/pom.xml
+++ b/clock/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-clock</artifactId>

--- a/clock/pom.xml
+++ b/clock/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-clock</artifactId>

--- a/clock/pom.xml
+++ b/clock/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-clock</artifactId>

--- a/clock/pom.xml
+++ b/clock/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-clock</artifactId>

--- a/clock/pom.xml
+++ b/clock/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-clock</artifactId>

--- a/clock/pom.xml
+++ b/clock/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-clock</artifactId>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-concurrent</artifactId>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-concurrent</artifactId>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-concurrent</artifactId>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-concurrent</artifactId>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-concurrent</artifactId>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-concurrent</artifactId>

--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-config-magic</artifactId>
@@ -66,7 +66,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- Don't run JUnit tests -->
-                    <groups/>
+                    <groups />
                 </configuration>
             </plugin>
         </plugins>

--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-config-magic</artifactId>
@@ -66,7 +66,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- Don't run JUnit tests -->
-                    <groups/>
+                    <groups />
                 </configuration>
             </plugin>
         </plugins>

--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-config-magic</artifactId>

--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-config-magic</artifactId>

--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-config-magic</artifactId>

--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-config-magic</artifactId>
@@ -66,7 +66,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- Don't run JUnit tests -->
-                    <groups/>
+                    <groups />
                 </configuration>
             </plugin>
         </plugins>

--- a/config-magic/pom.xml
+++ b/config-magic/pom.xml
@@ -66,7 +66,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- Don't run JUnit tests -->
-                    <groups />
+                    <groups/>
                 </configuration>
             </plugin>
         </plugins>

--- a/embeddeddb/common/pom.xml
+++ b/embeddeddb/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-common</artifactId>

--- a/embeddeddb/common/pom.xml
+++ b/embeddeddb/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-common</artifactId>

--- a/embeddeddb/common/pom.xml
+++ b/embeddeddb/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-common</artifactId>

--- a/embeddeddb/common/pom.xml
+++ b/embeddeddb/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-common</artifactId>

--- a/embeddeddb/common/pom.xml
+++ b/embeddeddb/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-common</artifactId>

--- a/embeddeddb/common/pom.xml
+++ b/embeddeddb/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-common</artifactId>

--- a/embeddeddb/h2/pom.xml
+++ b/embeddeddb/h2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-h2</artifactId>

--- a/embeddeddb/h2/pom.xml
+++ b/embeddeddb/h2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-h2</artifactId>

--- a/embeddeddb/h2/pom.xml
+++ b/embeddeddb/h2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-h2</artifactId>

--- a/embeddeddb/h2/pom.xml
+++ b/embeddeddb/h2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-h2</artifactId>

--- a/embeddeddb/h2/pom.xml
+++ b/embeddeddb/h2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-h2</artifactId>

--- a/embeddeddb/h2/pom.xml
+++ b/embeddeddb/h2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-h2</artifactId>

--- a/embeddeddb/mysql/pom.xml
+++ b/embeddeddb/mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-mysql</artifactId>

--- a/embeddeddb/mysql/pom.xml
+++ b/embeddeddb/mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-mysql</artifactId>

--- a/embeddeddb/mysql/pom.xml
+++ b/embeddeddb/mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-mysql</artifactId>

--- a/embeddeddb/mysql/pom.xml
+++ b/embeddeddb/mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-mysql</artifactId>

--- a/embeddeddb/mysql/pom.xml
+++ b/embeddeddb/mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-mysql</artifactId>

--- a/embeddeddb/mysql/pom.xml
+++ b/embeddeddb/mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-mysql</artifactId>

--- a/embeddeddb/pom.xml
+++ b/embeddeddb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb</artifactId>

--- a/embeddeddb/pom.xml
+++ b/embeddeddb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb</artifactId>

--- a/embeddeddb/pom.xml
+++ b/embeddeddb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb</artifactId>

--- a/embeddeddb/pom.xml
+++ b/embeddeddb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb</artifactId>

--- a/embeddeddb/pom.xml
+++ b/embeddeddb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb</artifactId>

--- a/embeddeddb/pom.xml
+++ b/embeddeddb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb</artifactId>

--- a/embeddeddb/postgresql/pom.xml
+++ b/embeddeddb/postgresql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-postgresql</artifactId>

--- a/embeddeddb/postgresql/pom.xml
+++ b/embeddeddb/postgresql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-postgresql</artifactId>

--- a/embeddeddb/postgresql/pom.xml
+++ b/embeddeddb/postgresql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-postgresql</artifactId>

--- a/embeddeddb/postgresql/pom.xml
+++ b/embeddeddb/postgresql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-postgresql</artifactId>

--- a/embeddeddb/postgresql/pom.xml
+++ b/embeddeddb/postgresql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-postgresql</artifactId>

--- a/embeddeddb/postgresql/pom.xml
+++ b/embeddeddb/postgresql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-embeddeddb</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-embeddeddb-postgresql</artifactId>

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jdbi</artifactId>

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jdbi</artifactId>

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jdbi</artifactId>

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jdbi</artifactId>

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jdbi</artifactId>

--- a/jdbi/pom.xml
+++ b/jdbi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jdbi</artifactId>

--- a/locker/pom.xml
+++ b/locker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-locker</artifactId>

--- a/locker/pom.xml
+++ b/locker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-locker</artifactId>

--- a/locker/pom.xml
+++ b/locker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-locker</artifactId>

--- a/locker/pom.xml
+++ b/locker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-locker</artifactId>

--- a/locker/pom.xml
+++ b/locker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-locker</artifactId>

--- a/locker/pom.xml
+++ b/locker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-locker</artifactId>

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
     </parent>
     <artifactId>killbill-metrics-api</artifactId>
     <properties>

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -20,11 +20,11 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-metrics-api</artifactId>
     <properties>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
     </properties>
-    <dependencies/>
+    <dependencies />
 </project>

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -20,12 +20,12 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-metrics-api</artifactId>
     <name>KillBill Metrics API</name>
     <properties>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
     </properties>
-    <dependencies/>
+    <dependencies />
 </project>

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
     </parent>
     <artifactId>killbill-metrics-api</artifactId>
     <properties>

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
     </parent>
     <artifactId>killbill-metrics-api</artifactId>
     <name>KillBill Metrics API</name>

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -26,5 +26,5 @@
     <properties>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
     </properties>
-    <dependencies />
+    <dependencies/>
 </project>

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -20,11 +20,11 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-metrics-api</artifactId>
     <properties>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
     </properties>
-    <dependencies/>
+    <dependencies />
 </project>

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -23,8 +23,9 @@
         <version>0.26.10-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-metrics-api</artifactId>
+    <name>KillBill Metrics API</name>
     <properties>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
     </properties>
-    <dependencies />
+    <dependencies/>
 </project>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
     </parent>
     <artifactId>killbill-metrics</artifactId>
     <properties>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-metrics</artifactId>
     <properties>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
     </parent>
     <artifactId>killbill-metrics</artifactId>
     <properties>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-metrics</artifactId>
     <properties>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
     </parent>
     <artifactId>killbill-metrics</artifactId>
     <name>KillBill Metrics</name>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -23,6 +23,7 @@
         <version>0.26.10-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-metrics</artifactId>
+    <name>KillBill Metrics</name>
     <properties>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
     </properties>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-metrics</artifactId>
     <name>KillBill Metrics</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>
-    <version>0.26.8</version>
+    <version>0.26.9-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>killbill-commons</name>
     <description>Kill Bill reusable Java components</description>
@@ -56,7 +56,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-commons.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill-commons.git</developerConnection>
-        <tag>killbill-commons-0.26.8</tag>
+        <tag>HEAD</tag>
         <url>http://github.com/killbill/killbill-commons/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>
-    <version>0.26.9-SNAPSHOT</version>
+    <version>0.26.9</version>
     <packaging>pom</packaging>
     <name>killbill-commons</name>
     <description>Kill Bill reusable Java components</description>
@@ -56,7 +56,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-commons.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill-commons.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>killbill-commons-0.26.9</tag>
         <url>http://github.com/killbill/killbill-commons/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>
-    <version>0.26.10-SNAPSHOT</version>
+    <version>0.26.10</version>
     <packaging>pom</packaging>
     <name>killbill-commons</name>
     <description>Kill Bill reusable Java components</description>
@@ -56,7 +56,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-commons.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill-commons.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>killbill-commons-0.26.10</tag>
         <url>http://github.com/killbill/killbill-commons/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>
-    <version>0.26.10</version>
+    <version>0.26.11-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>killbill-commons</name>
     <description>Kill Bill reusable Java components</description>
@@ -56,7 +56,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-commons.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill-commons.git</developerConnection>
-        <tag>killbill-commons-0.26.10</tag>
+        <tag>HEAD</tag>
         <url>http://github.com/killbill/killbill-commons/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.146.39</version>
+        <version>0.146.54</version>
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>
-    <version>0.26.8-SNAPSHOT</version>
+    <version>0.26.8</version>
     <packaging>pom</packaging>
     <name>killbill-commons</name>
     <description>Kill Bill reusable Java components</description>
@@ -56,7 +56,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-commons.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill-commons.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>killbill-commons-0.26.8</tag>
         <url>http://github.com/killbill/killbill-commons/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>
-    <version>0.26.9</version>
+    <version>0.26.10-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>killbill-commons</name>
     <description>Kill Bill reusable Java components</description>
@@ -56,7 +56,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-commons.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill-commons.git</developerConnection>
-        <tag>killbill-commons-0.26.9</tag>
+        <tag>HEAD</tag>
         <url>http://github.com/killbill/killbill-commons/tree/master</url>
     </scm>
     <issueManagement>

--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-queue</artifactId>

--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-queue</artifactId>

--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-queue</artifactId>

--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-queue</artifactId>

--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-queue</artifactId>

--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-queue</artifactId>

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-skeleton</artifactId>

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-skeleton</artifactId>

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-skeleton</artifactId>

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-skeleton</artifactId>

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-skeleton</artifactId>

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-skeleton</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/xmlloader/pom.xml
+++ b/xmlloader/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8</version>
+        <version>0.26.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-xmlloader</artifactId>

--- a/xmlloader/pom.xml
+++ b/xmlloader/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9</version>
+        <version>0.26.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-xmlloader</artifactId>

--- a/xmlloader/pom.xml
+++ b/xmlloader/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.9-SNAPSHOT</version>
+        <version>0.26.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-xmlloader</artifactId>

--- a/xmlloader/pom.xml
+++ b/xmlloader/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10</version>
+        <version>0.26.11-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-xmlloader</artifactId>

--- a/xmlloader/pom.xml
+++ b/xmlloader/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.10-SNAPSHOT</version>
+        <version>0.26.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-xmlloader</artifactId>

--- a/xmlloader/pom.xml
+++ b/xmlloader/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.commons</groupId>
         <artifactId>killbill-commons</artifactId>
-        <version>0.26.8-SNAPSHOT</version>
+        <version>0.26.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-xmlloader</artifactId>


### PR DESCRIPTION
Changes to fix release failure. snapshot release is also fixed. With this change, I've released version  `0.26.10` of `killbill-commons`.  If changes looks good, I would suggest "squash and merge" as there are a lot of intermediate commits for debugging purpose.