### PR TITLE
Improved config value collection and instance name replacement handling

### DIFF
--- a/config-magic/src/main/java/org/skife/config/AugmentedConfigurationObjectFactory.java
+++ b/config-magic/src/main/java/org/skife/config/AugmentedConfigurationObjectFactory.java
@@ -77,7 +77,6 @@ public class AugmentedConfigurationObjectFactory extends ConfigurationObjectFact
                             key = applyReplacements(key, mappedReplacements);
                         }
 
-                        RuntimeConfigRegistry.put(key, value);
                         RuntimeConfigRegistry.putWithSource(configSource, key, value);
                     }
                 } catch (final IllegalAccessException | InvocationTargetException e) {


### PR DESCRIPTION
* Overrode buildWithReplacements() to collect configuration values.
* Added applyReplacements() helper to resolve ${instanceName} placeholders.