### PR TITLE
remove netty dependency

### DIFF
--- a/clock/pom.xml
+++ b/clock/pom.xml
@@ -33,13 +33,6 @@
             <artifactId>guice</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <!-- required during redis testing (RedissonClient) -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-            <version>${netty.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
@@ -58,12 +51,6 @@
             <groupId>org.redisson</groupId>
             <artifactId>redisson</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/jooby/src/test/java/org/jooby/test/JoobySuite.java
+++ b/jooby/src/test/java/org/jooby/test/JoobySuite.java
@@ -35,10 +35,6 @@ public class JoobySuite extends Suite {
 
   private List<Runner> runners;
 
-  static {
-    System.setProperty("io.netty.leakDetectionLevel", "advanced");
-  }
-
   public JoobySuite(final Class<?> klass) throws InitializationError {
     super(klass, Collections.emptyList());
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.147.2</version>
+        <version>0.147.12-668a7e2-SNAPSHOT</version>
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>
@@ -183,4 +183,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Set as Draft PR, because currently the `killbill-oss-parent` using `SNAPSHOT` release. Could be merge to master candidate once oss-parent published without netty and used by this PR.

Versions:
- `0.27.2-e5cd695-SNAPSHOT`