### PR TITLE
remove netty

### DIFF
--- a/clock/pom.xml
+++ b/clock/pom.xml
@@ -33,13 +33,6 @@
             <artifactId>guice</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <!-- required during redis testing (RedissonClient) -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-            <version>${netty.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
@@ -58,12 +51,6 @@
             <groupId>org.redisson</groupId>
             <artifactId>redisson</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/jooby/src/test/java/org/jooby/test/JoobyRunner.java
+++ b/jooby/src/test/java/org/jooby/test/JoobyRunner.java
@@ -93,8 +93,7 @@ public class JoobyRunner extends BlockJUnit4ClassRunner {
           .withValue("server.threads.Max", ConfigValueFactory.fromAnyRef(maxThreads))
           .withValue("application.port", ConfigValueFactory.fromAnyRef(port))
           .withValue("undertow.ioThreads", ConfigValueFactory.fromAnyRef(2))
-          .withValue("undertow.workerThreads", ConfigValueFactory.fromAnyRef(4))
-          .withValue("netty.threads.Parent", ConfigValueFactory.fromAnyRef(2));
+          .withValue("undertow.workerThreads", ConfigValueFactory.fromAnyRef(4));
 
       if (server != null) {
         config = config.withFallback(ConfigFactory.empty()

--- a/jooby/src/test/java/org/jooby/test/JoobySuite.java
+++ b/jooby/src/test/java/org/jooby/test/JoobySuite.java
@@ -35,10 +35,6 @@ public class JoobySuite extends Suite {
 
   private List<Runner> runners;
 
-  static {
-    System.setProperty("io.netty.leakDetectionLevel", "advanced");
-  }
-
   public JoobySuite(final Class<?> klass) throws InitializationError {
     super(klass, Collections.emptyList());
 
@@ -54,8 +50,7 @@ public class JoobySuite extends Suite {
       List<Class<?>> server = Arrays.asList(onserver.value());
       filter = server::contains;
     }
-    String[] servers = {"org.jooby.undertow.Undertow", "org.jooby.jetty.Jetty",
-        "org.jooby.netty.Netty" };
+    String[] servers = {"org.jooby.jetty.Jetty"};
     for (String server : servers) {
       try {
         Class<?> serverClass = getClass().getClassLoader().loadClass(server);

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.147.2</version>
+        <version>0.147.14</version>
     </parent>
     <groupId>org.kill-bill.commons</groupId>
     <artifactId>killbill-commons</artifactId>


### PR DESCRIPTION
1. `clock` module doesn't actually need it. It is redisson that need netty.
2. Some jooby classes set netty config/properties. Netty support in `killbill-jobby` is removed, so configuration is not needed at all.